### PR TITLE
Count the frames in all recordings of a directory

### DIFF
--- a/io/count_frames_in_tif.m
+++ b/io/count_frames_in_tif.m
@@ -1,0 +1,26 @@
+function total_frames = count_frames_in_tif(path_to_tif)
+% Computes the number of frames contained in all TIF files of
+%   the specified directory
+%
+% Example use: "count_frames_in_tif(pwd)"
+%   in a directory that contains TIF files
+%
+% 2015-01-02 Tony Hyun Kim
+
+tif_files = dir(fullfile(path_to_tif,'*.tif'));
+num_files = length(tif_files);
+fprintf('Found %d TIF files in "%s"\n', num_files, path_to_tif);
+
+total_frames = 0;
+for i = 1:num_files
+    tif_filename = tif_files(i).name;
+    tif_info = imfinfo(tif_filename);
+    
+    num_frames = length(tif_info);
+    total_frames = total_frames + num_frames;
+    
+    fprintf('  %d: "%s" has %d frames\n',...
+        i, tif_filename, num_frames);
+end
+
+fprintf('  Total frame count is %d\n', total_frames);

--- a/io/count_frames_in_xml.m
+++ b/io/count_frames_in_xml.m
@@ -1,0 +1,38 @@
+function total_frames = count_frames_in_xml(path_to_xml)
+% Computes the number of frames contained in all Miniscope XML files
+%   of the specified directory. Gives a warning if the XML file is not
+%   matched by a corresponding RAW or TIF file.
+% 
+% Example use: "count_frames_in_xml(pwd)"
+%   in a directory that contains (only) Miniscope XML files
+%
+% 2015-01-01 Tony Hyun Kim
+
+xml_files = dir(fullfile(path_to_xml,'*.xml'));
+num_files = length(xml_files);
+fprintf('Found %d XML files in "%s"\n', num_files, path_to_xml);
+
+total_frames = 0;
+total_dropped_frames = 0;
+for i = 1:num_files
+    xml_filename = xml_files(i).name;
+    xml_struct = parse_miniscope_xml(xml_filename);
+
+    % Count frames
+    num_frames = str2double(xml_struct.frames);
+    num_dropped_frames = str2double(xml_struct.dropped_count);
+    
+    total_dropped_frames = total_dropped_frames + num_dropped_frames;
+    total_frames = total_frames + num_frames + num_dropped_frames;
+    
+    % Check if there is a corresponding RAW or TIF file
+    [~, name, ~] = fileparts(xml_filename);
+    raw = dir(fullfile(path_to_xml, strcat(name, '.raw')));
+    tif = dir(fullfile(path_to_xml, strcat(name, '.tif')));
+    if (isempty(raw) && isempty(tif))
+        fprintf('  Warning! "%s" is missing its RAW or TIF counterpart!\n',...
+            xml_filename);
+    end
+end
+fprintf('  Total frame count is %d (with %d dropped frames)\n',...
+    total_frames, total_dropped_frames);

--- a/io/count_frames_in_xml.m
+++ b/io/count_frames_in_xml.m
@@ -4,7 +4,7 @@ function total_frames = count_frames_in_xml(path_to_xml)
 %   matched by a corresponding RAW or TIF file.
 % 
 % Example use: "count_frames_in_xml(pwd)"
-%   in a directory that contains (only) Miniscope XML files
+%   in a directory that contains Miniscope XML files
 %
 % 2015-01-01 Tony Hyun Kim
 

--- a/io/parse_miniscope_xml.m
+++ b/io/parse_miniscope_xml.m
@@ -1,0 +1,32 @@
+function s = parse_miniscope_xml(source)
+
+s = struct;
+
+% Extract recording parameters
+xDoc = xmlread(source);
+allAttrs = xDoc.getElementsByTagName('attr');
+for k = 0:allAttrs.getLength-1
+    attr = allAttrs.item(k);
+    attr_type = char(attr.getAttributes.getNamedItem('name').getValue);
+    attr_val = char(attr.getFirstChild.getData);
+    s = setfield(s, attr_type, attr_val); %#ok<*SFLD>
+end
+
+% Extract the list of TIF files. The tag <file> shows up in two 
+%   different contexts in the Inscopix XML output. We want only the
+%   one that has <decompressed> as its direct parent. Furthermore, strip
+%   the absolute path since the files may have moved.
+file_names = cell(100,1);
+allFiles = xDoc.getElementsByTagName('file');
+num_files = 0;
+for k = 0:allFiles.getLength-1
+    file = allFiles.item(k);
+    if strcmp(file.getParentNode.getTagName, 'decompressed')
+        num_files = num_files + 1;
+        full_path = char(file.getFirstChild.getData);
+        [~, name, ext] = fileparts(full_path);
+        file_names{num_files} = strcat(name,ext);
+    end
+end
+s = setfield(s, 'num_files', num_files);
+s = setfield(s, 'files', file_names(1:num_files));


### PR DESCRIPTION
@forea

Running `count_frames_in_xml(pwd)` in a directory that contains Miniscope recordings (i.e. XML files) will aggregate the total number of frames indicated in all XML files. This function allows us to quickly assess the number of frames in a recording session, given that each trial is now a separate recording.

As courtesy, `count_frames_in_xml` will output a warning if it is unable to find a RAW or TIF file that corresponds to the XML file.

`parse_miniscope_xml` is a helper function that will parse (some of) the content of the Miniscope XML file into a format (struct) easily parsed in Matlab.