### PR TITLE
Kimth/io

### DIFF
--- a/io/compare_frames_in_xml_tif.m
+++ b/io/compare_frames_in_xml_tif.m
@@ -16,7 +16,7 @@ for i = 1:num_files
     [~, name, ~] = fileparts(xml_filename);
     tif = dir(fullfile(path_to_xml, strcat(name, '.tif')));
     if (isempty(tif))
-        fprintf('  Error! "%s" is missing its RAW or TIF counterpart!\n',...
+        fprintf('  Error! "%s" is missing its TIF counterpart!\n',...
             xml_filename);
         mismatch_detected = true;
         break;

--- a/io/compare_frames_in_xml_tif.m
+++ b/io/compare_frames_in_xml_tif.m
@@ -1,0 +1,38 @@
+function compare_frames_in_xml_tif(path_to_xml)
+
+xml_files = dir(fullfile(path_to_xml,'*.xml'));
+num_files = length(xml_files);
+fprintf('Found %d XML files in "%s"\n', num_files, path_to_xml);
+
+mismatch_detected = false;
+for i = 1:num_files
+    xml_filename = xml_files(i).name;
+    xml_struct = parse_miniscope_xml(xml_filename);
+
+    % Count frames in XML
+    num_frames = str2double(xml_struct.frames); 
+  
+    % Check the corresponding TIF file
+    [~, name, ~] = fileparts(xml_filename);
+    tif = dir(fullfile(path_to_xml, strcat(name, '.tif')));
+    if (isempty(tif))
+        fprintf('  Error! "%s" is missing its RAW or TIF counterpart!\n',...
+            xml_filename);
+        mismatch_detected = true;
+        break;
+    else
+        tif_filename = tif.name;
+        tif_info = imfinfo(tif_filename);
+        num_tif_frames = length(tif_info);
+        if (num_frames ~= num_tif_frames)
+            fprintf('  Error "%s" shows mismatch in XML (%d) and TIF (%d) frame counts!\n',...
+                xml_filename, num_frames, num_tif_frames);
+            mismatch_detected = true;
+            break;
+        end
+    end
+end
+
+if (~mismatch_detected)
+    fprintf('  No mismatch in %d XML/TIF pairs.\n', num_files);
+end

--- a/io/compare_frames_in_xml_tif.m
+++ b/io/compare_frames_in_xml_tif.m
@@ -1,4 +1,8 @@
 function compare_frames_in_xml_tif(path_to_xml)
+% For each XML file in the specified path, make sure that the
+% corresponding TIFF file has the same number of frames
+%
+% Tony Hyun Kim (2015 Jan 16)
 
 xml_files = dir(fullfile(path_to_xml,'*.xml'));
 num_files = length(xml_files);
@@ -6,7 +10,7 @@ fprintf('Found %d XML files in "%s"\n', num_files, path_to_xml);
 
 mismatch_detected = false;
 for i = 1:num_files
-    xml_filename = xml_files(i).name;
+    xml_filename = fullfile(path_to_xml, xml_files(i).name);
     xml_struct = parse_miniscope_xml(xml_filename);
 
     % Count frames in XML
@@ -21,7 +25,7 @@ for i = 1:num_files
         mismatch_detected = true;
         break;
     else
-        tif_filename = tif.name;
+        tif_filename = fullfile(path_to_xml, tif.name);
         tif_info = imfinfo(tif_filename);
         num_tif_frames = length(tif_info);
         if (num_frames ~= num_tif_frames)

--- a/io/count_frames_in_xml.m
+++ b/io/count_frames_in_xml.m
@@ -25,6 +25,9 @@ for i = 1:num_files
     total_dropped_frames = total_dropped_frames + num_dropped_frames;
     total_frames = total_frames + num_frames + num_dropped_frames;
     
+    fprintf('  %d: "%s" has %d frames and %d dropped frames\n',...
+        i, xml_filename, num_frames, num_dropped_frames);
+    
     % Check if there is a corresponding RAW or TIF file
     [~, name, ~] = fileparts(xml_filename);
     raw = dir(fullfile(path_to_xml, strcat(name, '.raw')));


### PR DESCRIPTION
@forea

The function `compare_frames_in_xml_tif(...)` helps to make sure that RAW file decompression didn't glitch, by checking the frame counts of each XML and TIFF file pair.

If a mismatch is detected, an error is issued. In all cases so far, re-decompressing the RAW file has taken care of such mismatches.