### PR TITLE
Kimth/hdf5

### DIFF
--- a/io/load_movie_from_hdf5.m
+++ b/io/load_movie_from_hdf5.m
@@ -1,0 +1,7 @@
+function M = load_movie_from_hdf5(source)
+% Load a movie matrix [height x width x num_frames] from a HDF5 file.
+%   Uses a default dataset name of "/movie"
+%
+% 2015 01 28 Tony Hyun Kim
+
+M = h5read(source, '/movie');

--- a/io/load_movie_from_hdf5.m
+++ b/io/load_movie_from_hdf5.m
@@ -1,7 +1,6 @@
-function M = load_movie_from_hdf5(source)
+function M = load_movie_from_hdf5(source, dataset_name)
 % Load a movie matrix [height x width x num_frames] from a HDF5 file.
-%   Uses a default dataset name of "/movie"
 %
 % 2015 01 28 Tony Hyun Kim
 
-M = h5read(source, '/movie');
+M = h5read(source, dataset_name)

--- a/io/load_movie_from_hdf5.m
+++ b/io/load_movie_from_hdf5.m
@@ -1,6 +1,12 @@
-function M = load_movie_from_hdf5(source, dataset_name)
+function M = load_movie_from_hdf5(source, varargin)
 % Load a movie matrix [height x width x num_frames] from a HDF5 file.
+%   Optional parameter to specify the dataset name.
 %
 % 2015 01 28 Tony Hyun Kim
+if isempty(varargin)
+    dataset_name = '/Data/Images';
+else
+    dataset_name = varargin{1};
+end
 
-M = h5read(source, dataset_name)
+M = h5read(source, dataset_name);

--- a/io/save_movie_to_hdf5.m
+++ b/io/save_movie_to_hdf5.m
@@ -1,7 +1,13 @@
-function save_movie_to_hdf5(movie, outname, dataset_name)
+function save_movie_to_hdf5(movie, outname, varargin)
 % Save a movie matrix [height x width x num_frames] into a HDF5 file.
+%   Optional parameter to specify the dataset name.
 %
 % 2015 01 28 Tony Hyun Kim
+if isempty(varargin)
+    dataset_name = '/Data/Images';
+else
+    dataset_name = varargin{1};
+end
 
 [height, width, num_frames] = size(movie);
 data_type = class(movie);

--- a/io/save_movie_to_hdf5.m
+++ b/io/save_movie_to_hdf5.m
@@ -1,0 +1,16 @@
+function save_movie_to_hdf5(movie, outname)
+% Save a movie matrix [height x width x num_frames] into a HDF5 file.
+%   Uses a default dataset name of "/movie"
+%
+% 2015 01 28 Tony Hyun Kim
+
+[height, width, num_frames] = size(movie);
+data_type = class(movie);
+
+dataset_name = '/movie';
+chunk_size = [height width 1];
+
+h5create(outname, dataset_name, [height width num_frames],...
+    'DataType', data_type,...
+    'ChunkSize', chunk_size);
+h5write(outname, dataset_name, movie);

--- a/io/save_movie_to_hdf5.m
+++ b/io/save_movie_to_hdf5.m
@@ -1,13 +1,11 @@
-function save_movie_to_hdf5(movie, outname)
+function save_movie_to_hdf5(movie, outname, dataset_name)
 % Save a movie matrix [height x width x num_frames] into a HDF5 file.
-%   Uses a default dataset name of "/movie"
 %
 % 2015 01 28 Tony Hyun Kim
 
 [height, width, num_frames] = size(movie);
 data_type = class(movie);
 
-dataset_name = '/movie';
 chunk_size = [height width 1];
 
 h5create(outname, dataset_name, [height width num_frames],...

--- a/io/save_movie_to_tif.m
+++ b/io/save_movie_to_tif.m
@@ -1,0 +1,38 @@
+function save_movie_to_tif(movie, outname, type)
+% Save a movie as a BigTiff stack that is compatible with Mosaic
+
+[height, width, num_frames] = size(movie);
+
+% Prepare Tiff tags
+tagstruct.ImageLength = height;
+tagstruct.ImageWidth = width;
+tagstruct.Photometric = Tiff.Photometric.MinIsBlack;
+tagstruct.SamplesPerPixel = 1;
+tagstruct.Compression = Tiff.Compression.None;
+tagstruct.PlanarConfiguration = Tiff.PlanarConfiguration.Chunky;
+tagstruct.Orientation = Tiff.Orientation.TopLeft;
+switch (lower(type))
+    case 'single'
+        tagstruct.SampleFormat = Tiff.SampleFormat.IEEEFP;
+        tagstruct.BitsPerSample = 32;
+    case 'uint'
+        tagstruct.SampleFormat = Tiff.SampleFormat.UInt;
+        tagstruct.BitsPerSample = 16;
+    otherwise
+        error('save_movie_to_tif.m: Unrecognized type "%s"\n', type);
+end
+
+t = Tiff(outname, 'w8'); % BigTiff format
+for k = 1:num_frames
+    if (mod(k,1000)==0)
+        fprintf('  Frames %d / %d written to %s (%s)\n',...
+            k, num_frames, outname, datestr(now));
+    end
+    if (k ~= 1)
+        t.writeDirectory();
+    end
+    t.setTag(tagstruct);
+    t.write(movie(:,:,k));
+end
+t.close();
+fprintf('  All done! (%s)\n', datestr(now));

--- a/io/save_movie_to_tif.m
+++ b/io/save_movie_to_tif.m
@@ -1,7 +1,8 @@
-function save_movie_to_tif(movie, outname, type)
+function save_movie_to_tif(movie, outname)
 % Save a movie as a BigTiff stack that is compatible with Mosaic
 
 [height, width, num_frames] = size(movie);
+type = class(movie);
 
 % Prepare Tiff tags
 tagstruct.ImageLength = height;
@@ -15,7 +16,7 @@ switch (lower(type))
     case 'single'
         tagstruct.SampleFormat = Tiff.SampleFormat.IEEEFP;
         tagstruct.BitsPerSample = 32;
-    case 'uint'
+    case 'uint16'
         tagstruct.SampleFormat = Tiff.SampleFormat.UInt;
         tagstruct.BitsPerSample = 16;
     otherwise

--- a/io/save_movie_to_tif.m
+++ b/io/save_movie_to_tif.m
@@ -1,5 +1,7 @@
 function save_movie_to_tif(movie, outname)
-% Save a movie as a BigTiff stack that is compatible with Mosaic
+% Save a movie [height x width x num_frames] as a BigTiff stack that is compatible with Mosaic
+%
+% 2015 01 28 Tony Hyun Kim
 
 [height, width, num_frames] = size(movie);
 type = class(movie);


### PR DESCRIPTION
@jmaxey Generic saving and loading of movies (three-dimensional matrices `[height width num_frames]`) via HDF5 files. Uses a default dataset name of `/movie` (we can adopt a different standard, feel free to suggest).

For completeness, I also added a script that saves a movie in memory to BigTiff format that is compatible with Mosaic. (The script for loading a TIFF file into memory is already in master.)

