### PR TITLE
3 movie normalization routines to be applied sequentially

### DIFF
--- a/image_op/compute_mean_fluorescence.m
+++ b/image_op/compute_mean_fluorescence.m
@@ -1,0 +1,12 @@
+function F = compute_mean_fluorescence(M)
+% Compute the mean fluorescence of a movie M on a frame-by-frame basis.
+%   M: [h x w x num_frames]
+%
+% 2015 01 31 Tony Hyun Kim
+
+num_frames = size(M,3);
+F = zeros(1,num_frames);
+for i = 1:num_frames
+    m = M(:,:,i);
+    F(i) = mean(m(:));
+end

--- a/image_op/fit_mean_fluorescence.m
+++ b/image_op/fit_mean_fluorescence.m
@@ -1,0 +1,22 @@
+function M_norm = fit_mean_fluorescence(movie)
+% Fit a sum of two exponentials to the mean flourescence
+%
+%   movie: movie matrix , [h x w x num_frames]
+%
+% 2015 01 31 Tony Hyun Kim (Revised: Hakan Inan, 15-Jan-4)
+%
+
+F = compute_mean_fluorescence(movie);
+num_frames = length(F);
+
+time = 1/20*(0:(num_frames-1));
+
+f2 = fit(time',F','exp2');%fit sum of 2 exponentials
+params = coeffvalues(f2);
+F_fit = params(1)*exp(params(2)*time) + params(3)*exp(params(4)*time);
+
+% Normalize movie
+M_norm = zeros(size(movie), 'single');
+for i = 1:num_frames
+    M_norm(:,:,i) = single(movie(:,:,i))/F_fit(i);
+end

--- a/image_op/norm_by_background_mean.m
+++ b/image_op/norm_by_background_mean.m
@@ -1,0 +1,22 @@
+function M_norm = norm_by_background_mean(movie)
+%Normalizes every frame in the movie by the mean pixel value of the
+%background to mitigate the temporal variation in the brightness
+%
+%   movie: movie matrix , [h x w x num_frames]
+%
+% Hakan Inan, 15-Jan-4
+%
+
+M_norm = zeros(size(movie),'single');
+[height,width,numFrames] = size(movie);
+
+for k = 1:numFrames
+    if (mod(k,1000)==0)
+        fprintf('  Frames %d of %d done\n', k, numFrames);
+    end
+    Frame = reshape(movie(:,:,k),height*width,1);
+    thresh = quantile(Frame,0.7);
+    Z = mean(Frame(Frame<thresh));
+    M_norm(:,:,k) = M_norm(:,:,k)/Z; %normalize by Z
+end
+

--- a/image_op/norm_by_background_mean.m
+++ b/image_op/norm_by_background_mean.m
@@ -17,6 +17,6 @@ for k = 1:numFrames
     Frame = reshape(movie(:,:,k),height*width,1);
     thresh = quantile(Frame,0.7);
     Z = mean(Frame(Frame<thresh));
-    M_norm(:,:,k) = M_norm(:,:,k)/Z; %normalize by Z
+    M_norm(:,:,k) = movie(:,:,k)/Z; %normalize by Z
 end
 

--- a/image_op/norm_by_background_mean.m
+++ b/image_op/norm_by_background_mean.m
@@ -1,11 +1,28 @@
-function M_norm = norm_by_background_mean(movie)
+function M_norm = norm_by_background_mean(movie,varargin)
 %Normalizes every frame in the movie by the mean pixel value of the
 %background to mitigate the temporal variation in the brightness
 %
-%   movie: movie matrix , [h x w x num_frames]
+%   movie: movie matrix(single) , [h x w x num_frames]
+%   [quant_lower,quant_upper] (optional): the lower and upper quantiles of 
+%   each frame to be used in background mean calculation. Default is
+%   [0.4,0.7].
 %
-% Hakan Inan, 15-Jan-4
+% Hakan Inan, 15-Jan-4 (Latest Revision: Hakan Inan, 15-Jan-5)
 %
+
+if isempty(varargin)
+    quant_lower = 0.4;
+    quant_upper = 0.7;
+elseif length(varargin) == 1
+    if length(varargin{1}) ==2
+        quant_lower = varargin{1}(1);
+        quant_upper = varargin{1}(2);
+    else
+        error('input should be of the form [quant_lower,quant_upper]');
+    end
+else
+    error('Only 1 variable input argument is allowed');
+end
 
 M_norm = zeros(size(movie),'single');
 [height,width,numFrames] = size(movie);
@@ -15,8 +32,9 @@ for k = 1:numFrames
         fprintf('  Frames %d of %d done\n', k, numFrames);
     end
     Frame = reshape(movie(:,:,k),height*width,1);
-    thresh = quantile(Frame,0.7);
-    Z = mean(Frame(Frame<thresh));
+    thresh_lower = quantile(Frame,quant_lower);
+    thresh_upper = quantile(Frame,quant_upper);
+    Z = mean(Frame(Frame>thresh_lower & Frame<thresh_upper));
     M_norm(:,:,k) = movie(:,:,k)/Z; %normalize by Z
 end
 

--- a/image_op/norm_by_disk_filter.m
+++ b/image_op/norm_by_disk_filter.m
@@ -1,0 +1,24 @@
+function M_norm = norm_by_disk_filter(movie)
+%Normalize every frame in the movie by a disk filtered version of itself
+%
+%   movie: movie matrix , [h x w x num_frames]
+%
+% 2015 01 31 Tony Hyun Kim (Revised: Hakan Inan, 15-Jan-4)
+%
+
+M_norm = zeros(size(movie), 'single');
+
+% Apply spatial normalization
+hDisk = fspecial('disk', 15);
+m_f = imfilter(movie(:,:,1), hDisk, 'replicate');
+m0 = mean(m_f(:));
+
+for i = 1:num_frames
+    if (mod(i,1000)==0)
+        fprintf('  Frames %d of %d done\n', i, num_frames);
+    end
+    m_f = imfilter(movie(:,:,i), hDisk, 'replicate');
+    m1 = mean(m_f(:));
+    m_f = m0/m1*m_f;
+    M_norm(:,:,i) = movie(:,:,i)./m_f;
+end

--- a/image_op/norm_by_disk_filter.m
+++ b/image_op/norm_by_disk_filter.m
@@ -7,7 +7,7 @@ function M_norm = norm_by_disk_filter(movie)
 %
 
 M_norm = zeros(size(movie), 'single');
-
+num_frames = size(movie,3);
 % Apply spatial normalization
 hDisk = fspecial('disk', 15);
 m_f = imfilter(movie(:,:,1), hDisk, 'replicate');

--- a/image_op/norm_by_disk_filter.m
+++ b/image_op/norm_by_disk_filter.m
@@ -1,15 +1,24 @@
-function M_norm = norm_by_disk_filter(movie)
+function M_norm = norm_by_disk_filter(movie,varargin)
 %Normalize every frame in the movie by a disk filtered version of itself
 %
-%   movie: movie matrix , [h x w x num_frames]
+%   movie: movie matrix(must be single) , [h x w x num_frames]
+%   disk_radius may be passed as an input argument. Default for disk_radius
+%   is 15.
+% 2015 01 31 Tony Hyun Kim (Latest Revision: Hakan Inan, 15-Jan-5)
 %
-% 2015 01 31 Tony Hyun Kim (Revised: Hakan Inan, 15-Jan-4)
-%
+
+if isempty(varargin)
+    disk_radius = 15;
+elseif length(varargin) == 1
+    disk_radius = varargin{1};
+else
+    error('Only 1 variable input argument is allowed');
+end
 
 M_norm = zeros(size(movie), 'single');
 num_frames = size(movie,3);
 % Apply spatial normalization
-hDisk = fspecial('disk', 15);
+hDisk = fspecial('disk', disk_radius);
 m_f = imfilter(movie(:,:,1), hDisk, 'replicate');
 m0 = mean(m_f(:));
 


### PR DESCRIPTION
@kimtonyhyun 

Added 3 normalization routines. 
1) fit_mean_fluorescence.m: inverts the exponential trend
    -uses compute_mean_fluorescence.m to calculate the mean fluorescence

2) norm_by_disk_filter.m : normalizes frames by the disk filter output

3) norm_by_background_mean.m: normalizes by the mean background fluorescence(would probably be ok to simply normalize by the total mean fluorescence)


