### PR TITLE
Kimth/classify without phase

### DIFF
--- a/classification/support/view_ic_pair.m
+++ b/classification/support/view_ic_pair.m
@@ -1,0 +1,31 @@
+function view_ic_pair(time, trace, filter)
+% Plot IC trace and IC filter (as a 3D graph)
+%
+% 2015 02 08 Tony Hyun Kim
+
+subplot(3,1,[2 3]);
+surf(double(filter)); % 'surf' doesn't take single
+colormap jet;
+shading flat;
+[h, w] = size(filter);
+xlim([1 w]);
+ylim([1 h]);
+z_min = min(filter(:));
+z_max = max(filter(:));
+z_range = z_max - z_min;
+zlim([z_min z_max] + 0.1*z_range*[-1 1]);
+daspect([1 1 z_range/max(h,w)]);
+xlabel('x [px]');
+ylabel('y [px]');
+set(gca, 'YDir', 'Reverse');
+zlabel('IC filter [a.u.]');
+
+subplot(3,1,1);
+plot(time, trace);
+t_min = min(trace);
+t_max = max(trace);
+t_range = t_max - t_min;
+xlim([time(1) time(end)]);
+ylim([t_min t_max] + 0.1*t_range*[-1 1]);
+xlabel('Time [s]');
+ylabel('IC trace [a.u.]');

--- a/classification/support/view_trace.m
+++ b/classification/support/view_trace.m
@@ -9,17 +9,18 @@ mad_threshold_scale = 8;
 mad = compute_mad(trace);
 thresh = mad_threshold_scale*mad;
 
-% Display the trace
 clf;
-subplot(3,1,1);
-view_trials_in_trace_by_color(time, trace, frame_indices);
-hold on;
-plot([time(1) time(end)], thresh*[1 1], 'r--', 'LineWidth', 2);
-hold off;
-
 subplot(3,1,[2 3]);
 % set(gcf, 'units', 'normalized', 'outerposition', [0 0 1 1]); % Maximize figure
 view_superimposed_trials_in_trace(time, trace, frame_indices);
 hold on;
 plot([0 1], thresh*[1 1], 'r--', 'LineWidth', 2);
+hold off;
+
+% Display the trace
+subplot(3,1,1); % Ending on 311 makes it so that subsequent calls to plot
+                %   e.g. 'title' go to the top panel
+view_trials_in_trace_by_color(time, trace, frame_indices);
+hold on;
+plot([time(1) time(end)], thresh*[1 1], 'r--', 'LineWidth', 2);
 hold off;


### PR DESCRIPTION
@inanhkn @forea This PR adds the following features to the `classify_ics` routine.

**Compatibility with temporally-binned movies:**
- Allow `classify_ics` to work with temporally-binned movies for which the `trial_frame_indices` (from the PlusMaze text file) do not match the movie frames. Where we used to display the trace color-coded by trial (and superimposed on one another), we now just see the IC trace and filter.
- For movies whose frames match the `trial_frame_indices`, the behavior is unchanged from before.

**Reduce flickering in movie playback:**
- Previously, we were performing per-frame scaling (as well as some per-frame computation -- more later) that resulted in flickering movies during IC trace / movie playback. We recently introduced a common `CLim` (i.e. common scaling) to all frames. I moved the computation of the common `CLim` into `classify_ics` (from the inner-function `view_ic_over_movie_interactively`) since it only needs to be computed once.
- In follow-up PRs, we should improve on the auto-detection of the appropriate `CLim` from the movie. What I've included here is just the basic skeleton.
- Previously, I had used a hack for drawing a black outline of the IC over the movie, which involved some per-frame calculations that -- in retrospect -- was making the movie playback more "flickery". I now use a different (Matlab) method for computing the border of the IC filter, and a different approach for overlaying the outline over the movie. The new overlay approach gives: (1) better performance, (2) allows use of non-BW colors for the outline, and (3) does not introduce flicker to the movie playback. The new overlay looks like this (i.e. note the red outline):
![20150208_ic-overlay](https://cloud.githubusercontent.com/assets/2081503/6100673/c01e6652-afc8-11e4-96b1-c3d43b93c3d9.png)

