### PR TITLE
Kimth/preprocessing

### DIFF
--- a/image_op/fit_mean_fluorescence.m
+++ b/image_op/fit_mean_fluorescence.m
@@ -1,22 +1,13 @@
-function M_norm = fit_mean_fluorescence(movie)
-% Fit a sum of two exponentials to the mean flourescence
-%
-%   movie: movie matrix , [h x w x num_frames]
+function F_fit = fit_mean_fluorescence(F)
+% Fit a sum of two exponentials to the mean flourescence F
 %
 % 2015 01 31 Tony Hyun Kim (Revised: Hakan Inan, 15-Jan-4)
 %
 
-F = compute_mean_fluorescence(movie);
 num_frames = length(F);
 
-time = 1/20*(0:(num_frames-1));
+time = 0:(num_frames-1);
 
-f2 = fit(time',F','exp2');%fit sum of 2 exponentials
+f2 = fit(time',F','exp2'); % Fit sum of 2 exponentials
 params = coeffvalues(f2);
 F_fit = params(1)*exp(params(2)*time) + params(3)*exp(params(4)*time);
-
-% Normalize movie
-M_norm = zeros(size(movie), 'single');
-for i = 1:num_frames
-    M_norm(:,:,i) = single(movie(:,:,i))/F_fit(i);
-end

--- a/image_op/norm_by_background_mean.m
+++ b/image_op/norm_by_background_mean.m
@@ -32,9 +32,8 @@ for k = 1:numFrames
         fprintf('  Frames %d of %d done\n', k, numFrames);
     end
     Frame = reshape(movie(:,:,k),height*width,1);
-    thresh_lower = quantile(Frame,quant_lower);
-    thresh_upper = quantile(Frame,quant_upper);
-    Z = mean(Frame(Frame>thresh_lower & Frame<thresh_upper));
-    M_norm(:,:,k) = movie(:,:,k)/Z; %normalize by Z
+    thresh = quantile(Frame,[quant_lower quant_upper]);
+    Z = mean(Frame(Frame>thresh(1) & Frame<thresh(2)));
+    M_norm(:,:,k) = movie(:,:,k)/Z;
 end
 

--- a/image_op/norm_by_disk_filter.m
+++ b/image_op/norm_by_disk_filter.m
@@ -1,7 +1,7 @@
 function M_norm = norm_by_disk_filter(movie,varargin)
 %Normalize every frame in the movie by a disk filtered version of itself
 %
-%   movie: movie matrix(must be single) , [h x w x num_frames]
+%   movie: movie matrix, [h x w x num_frames]
 %   disk_radius may be passed as an input argument. Default for disk_radius
 %   is 15.
 % 2015 01 31 Tony Hyun Kim (Latest Revision: Hakan Inan, 15-Jan-5)
@@ -17,17 +17,26 @@ end
 
 M_norm = zeros(size(movie), 'single');
 num_frames = size(movie,3);
+
 % Apply spatial normalization
 hDisk = fspecial('disk', disk_radius);
-m_f = imfilter(movie(:,:,1), hDisk, 'replicate');
+
+ref_idx = 1;
+m_f = imfilter(single(movie(:,:,ref_idx)), hDisk, 'replicate');
 m0 = mean(m_f(:));
+imagesc(m_f);
+xlabel('x [px]');
+ylabel('y [px]');
+title(sprintf('Frame %d filtered by disk of radius %d', ref_idx, disk_radius));
+input('norm_by_disk_filter: Press enter to proceed >> ');
 
 for i = 1:num_frames
     if (mod(i,1000)==0)
         fprintf('  Frames %d of %d done\n', i, num_frames);
     end
-    m_f = imfilter(movie(:,:,i), hDisk, 'replicate');
+    m = single(movie(:,:,i));
+    m_f = imfilter(m, hDisk, 'replicate');
     m1 = mean(m_f(:));
     m_f = m0/m1*m_f;
-    M_norm(:,:,i) = movie(:,:,i)./m_f;
+    M_norm(:,:,i) = m./m_f;
 end


### PR DESCRIPTION
@inanhkn Slight changes to the recently merged functions.

- `fit_mean_fluorescence`: now only fits the fluorescence variation with two exponentials (and doesn't actually normalize the movie)
- `norm_by_disk_filter`: Internally converts each input frame into a single, so that the input movie can also be an integer type (as would be the case if this is the first operation on the raw movie). Also, shows the result of disk filtering on a reference frame (currently the first frame of the movie), and prompts the user before continuing.
- `norm_by_background_mean`: Combine the two `quantile` operations into one, for efficiency.