### PR TITLE
fix the common scaling routine

### DIFF
--- a/classification/classify_ics.m
+++ b/classification/classify_ics.m
@@ -30,8 +30,9 @@ num_ics = ica_info.num_ICs;
 % Compute a common scaling for the movie
 maxVec = reshape(max(M,[],3), height*width, 1);
 minVec = reshape(min(M,[],3), height*width, 1);
-rangeVec = maxVec - minVec;
-movie_clim = median(rangeVec)*[-0.1 0.25];
+quantsMax = quantile(maxVec,[0.85,0.87,0.9,0.93,0.95]);
+quantsMin = quantile(minVec,[0.85,0.87,0.9,0.93,0.95]);
+movie_clim = [mean(quantsMin),mean(quantsMax)]*1.1;
 clear maxVec minVec rangeVec;
 fprintf('  %s: Movie will be displayed with fixed CLim = [%.3f %.3f]...\n',...
     datestr(now), movie_clim(1), movie_clim(2));

--- a/classification/support/view_ic_over_movie_interactively.m
+++ b/classification/support/view_ic_over_movie_interactively.m
@@ -111,7 +111,7 @@ end
                      active_periods(selected_idx,2);
             for k = frames
                 A = movie(:,:,k);
-                A = A - mean(A(:));
+               % A = A - mean(A(:));
                 set(h, 'CData', A);
 
                 % Update time indicators and dot


### PR DESCRIPTION
@kimtonyhyun 
The CLim calculation routine in `classify_ics.m` now considers pixel values lying in the upper tail of the min and max projections of the movie for lower and upper limits, respectively.
I also commented out the line that removes the mean fleurescence from each frame (for display) in  `view_ic_over_movie_interactively.m` . So don't run `classify_ics.m` on a movie that didn't go through background normalization.