### PR TITLE
Minor adjustments

### DIFF
--- a/classification/support/view_ic_pair.m
+++ b/classification/support/view_ic_pair.m
@@ -18,6 +18,7 @@ daspect([1 1 z_range/max(h,w)]);
 xlabel('x [px]');
 ylabel('y [px]');
 set(gca, 'YDir', 'Reverse');
+view([0 90]);
 zlabel('IC filter [a.u.]');
 
 subplot(3,1,1);

--- a/image_op/bin_movie_in_time.m
+++ b/image_op/bin_movie_in_time.m
@@ -10,7 +10,7 @@ function M_b = bin_movie_in_time(M, bin_factor)
 num_downsampled_frames = floor(num_frames/bin_factor); % Note truncation
 fprintf('Actual bin factor: %.3f\n', num_frames/num_downsampled_frames);
 
-M_b = zeros(height, width, num_downsampled_frames, class(M));
+M_b = zeros(height, width, num_downsampled_frames, 'single');
 for k = 1:num_downsampled_frames
     if (mod(k, 1000)==0)
         fprintf('  Frames %d / %d downsampled\n', k, num_downsampled_frames);

--- a/image_op/norm_by_background_mean.m
+++ b/image_op/norm_by_background_mean.m
@@ -31,9 +31,13 @@ for k = 1:numFrames
     if (mod(k,1000)==0)
         fprintf('  Frames %d of %d done\n', k, numFrames);
     end
-    Frame = reshape(movie(:,:,k),height*width,1);
-    thresh = quantile(Frame,[quant_lower quant_upper]);
-    Z = mean(Frame(Frame>thresh(1) & Frame<thresh(2)));
+    frame = reshape(movie(:,:,k),height*width,1);
+    if ((quant_lower==0) && (quant_upper==1)) % Use simple mean
+        Z = mean(frame(:));
+    else
+        thresh = quantile(frame, [quant_lower quant_upper]);
+        Z = mean(frame(frame>thresh(1) & frame<thresh(2)));
+    end
     M_norm(:,:,k) = movie(:,:,k)/Z;
 end
 


### PR DESCRIPTION
@inanhkn Few minor adjustments from today:
- `view_ic_pair`: Now makes it so that the 3D view of the IC filter (in `classify_ics`) now starts off from a top-down view (see attached picture).
- `bin_movie_in_time`: The resultant movie should be floating point, since averaging multiple (integer-pixel) frames can still yield non-floating point results.
- `norm_by_background_mean`: In the special case where the quantile bounds are set to `[0 1]` (i.e. the full range) then avoid the `quantile` operation. (By the way, I've been looking at some per-frame histograms... I'm not sure that the `quantile` filtering is playing a significant effect.)

Top-down view of IC filter:
![20150212_ic-filter_topdown](https://cloud.githubusercontent.com/assets/2081503/6182849/abcb2646-b300-11e4-9303-ba7c2bf627da.PNG)
