### PR TITLE
Extract movie scale computation

### DIFF
--- a/classification/classify_ics.m
+++ b/classification/classify_ics.m
@@ -20,7 +20,7 @@ load(ica_source, 'ica_info', 'ica_filters', 'ica_traces');
 %------------------------------------------------------------
 fprintf('  %s: Loading "%s" to memory...\n', datestr(now), sources.miniscope);
 M = load_movie(sources.miniscope);
-[height, width, num_frames] = size(M);
+num_frames = size(M,3);
 fprintf('  %s: Done!\n', datestr(now));
 
 fps = sources.fps;
@@ -28,12 +28,7 @@ time = 1/fps*((1:size(ica_traces,1))-1); %#ok<*NODEF>
 num_ics = ica_info.num_ICs;
 
 % Compute a common scaling for the movie
-maxVec = reshape(max(M,[],3), height*width, 1);
-minVec = reshape(min(M,[],3), height*width, 1);
-quantsMax = quantile(maxVec,[0.85,0.87,0.9,0.93,0.95]);
-quantsMin = quantile(minVec,[0.85,0.87,0.9,0.93,0.95]);
-movie_clim = [mean(quantsMin),mean(quantsMax)]*1.1;
-clear maxVec minVec rangeVec;
+movie_clim = compute_movie_scale(M);
 fprintf('  %s: Movie will be displayed with fixed CLim = [%.3f %.3f]...\n',...
     datestr(now), movie_clim(1), movie_clim(2));
 

--- a/image_op/compute_movie_scale.m
+++ b/image_op/compute_movie_scale.m
@@ -1,0 +1,9 @@
+function clim = compute_movie_scale(M)
+% Compute an appropriate viewing scale (CLim) for the provided movie
+
+[height, width, ~] = size(M);
+maxVec = reshape(max(M,[],3), height*width, 1);
+minVec = reshape(min(M,[],3), height*width, 1);
+quantsMax = quantile(maxVec,[0.85,0.87,0.9,0.93,0.95]);
+quantsMin = quantile(minVec,[0.85,0.87,0.9,0.93,0.95]);
+clim = [mean(quantsMin),mean(quantsMax)]*1.1;

--- a/view/view_movie.m
+++ b/view/view_movie.m
@@ -13,6 +13,7 @@ num_frames = size(M,3);
 movie_clim = compute_movie_scale(M);
 h = imagesc(M(:,:,1), movie_clim);
 axis image;
+truesize;
 colormap gray;
 xlabel('x [px]');
 ylabel('y [px]');

--- a/view/view_movie.m
+++ b/view/view_movie.m
@@ -10,7 +10,8 @@ end
 
 num_frames = size(M,3);
 
-h = imagesc(M(:,:,1));
+movie_clim = compute_movie_scale(M);
+h = imagesc(M(:,:,1), movie_clim);
 axis image;
 colormap gray;
 xlabel('x [px]');


### PR DESCRIPTION
The computation of a fixed `CLim` for a given movie has been extracted to its own function (`compute_movie_scale`). Both `classify_ics` and `view_movie` now use this function to determine an appropriate, _fixed_ viewing scale for the movie.