### PR TITLE
Kimth/alignment

### DIFF
--- a/alignment/compute_affine_transform.m
+++ b/alignment/compute_affine_transform.m
@@ -1,0 +1,191 @@
+function [masks1, masks2, info] = compute_affine_transform(source_dir1, source_dir2)
+% IC map alignment based on user-defined control points.
+%
+% Inputs:
+%   source_dirX: Path to directory containing ICA (ica_*.mat) and
+%       classification (class_*.txt) outputs
+%
+% Outputs:
+%   masks1: Cell array containing thresholded IC masks for source 1
+%   masks2: Cell array containing _transformed_ thresholded IC masks
+%           for source 2. (Note that the image dimensions match the
+%           dimensions of source 1 masks!)
+%
+% Tony Hyun Kim (2015 Feb 26)
+
+num_ics_for_alignment = 3;
+ic_filter_threshold = 0.3;
+
+% Load data
+%------------------------------------------------------------
+sources = {source_dir1, source_dir2};
+s1 = load(get_most_recent_file(sources{1}, 'ica_*.mat'));
+c1 = load_classification(get_most_recent_file(sources{1}, 'class_*.txt'));
+
+s2 = load(get_most_recent_file(sources{2}, 'ica_*.mat'));
+c2 = load_classification(get_most_recent_file(sources{2}, 'class_*.txt'));
+
+bounds = cell(1,2); % Boundaries of ICs
+masks  = cell(1,2); % BW image of thresholded ICs
+
+% Display the two sets of ICs
+figure;
+ax1 = subplot(121);
+[bounds{1}, masks{1}] = plot_ic_filters(s1.ica_filters, c1, ic_filter_threshold);
+title(strrep(sources{1},'_','\_'));
+
+ax2 = subplot(122);
+[bounds{2}, masks{2}] = plot_ic_filters(s2.ica_filters, c2, ic_filter_threshold);
+title(strrep(sources{2},'_','\_'));
+
+% Allow the user to select the ICs used in matching
+%------------------------------------------------------------
+sel_colors = 'ybk';
+fprintf('Please select %d ICs from each dataset (in order)\n',...
+    num_ics_for_alignment);
+
+sel_ics = zeros(num_ics_for_alignment,2); % List of selected ICs
+sel_ics_centers = zeros(num_ics_for_alignment, 2, 2); % XY position of each selected IC
+sel_ics_idx = [0 0]; % Number of ICs selected from each dataset
+
+% Loop until required number of ICs have been selected
+while (~all(sel_ics_idx == num_ics_for_alignment))
+    click_xy = round(ginput(1)); % Get user click
+    if (gca == ax1) % Axis 1 was clicked
+        source_idx = 1;
+    elseif (gca == ax2)
+        source_idx = 2;
+    end
+    
+    ic_idx = get_selected_ic_idx(bounds{source_idx}, click_xy);
+    if ~isempty(ic_idx)
+        sel_idx = sel_ics_idx(source_idx) + 1;
+        if (sel_idx <= num_ics_for_alignment)
+            fill(bounds{source_idx}{ic_idx}(:,1),...
+                 bounds{source_idx}{ic_idx}(:,2),...
+                 sel_colors(mod(sel_idx,length(sel_colors))+1));
+
+            props = regionprops(masks{source_idx}{ic_idx},'centroid');
+            fprintf('%s: IC %d selected (at [%.1f %.1f])!\n',...
+                sources{source_idx}, ic_idx,...
+                props.Centroid(1), props.Centroid(2));
+            
+            sel_ics(sel_idx, source_idx) = ic_idx;
+            sel_ics_idx(source_idx) = sel_idx;
+            sel_ics_centers(sel_idx,:,source_idx) = props.Centroid;
+        else
+            fprintf('  No more ICs needed from %s!\n',...
+                sources{source_idx});
+        end
+    else
+        fprintf('  No IC detected at cursor (%s)!\n',...
+            sources{source_idx});
+    end
+end
+fprintf('  All reference ICs selected!\n');
+
+% Transform Source2 onto Source1
+%------------------------------------------------------------
+tform = fitgeotrans(sel_ics_centers(:,:,2),... % Moving points
+                    sel_ics_centers(:,:,1),... % Fixed points
+                    'affine');
+
+figure;
+subplot(121); % Pre-transform comparison
+plot_boundaries(bounds{1}, c1, 'b', sel_ics(:,1), []);
+plot_boundaries(bounds{2}, c2, 'r', sel_ics(:,2), []);
+title(sprintf('Pre-transform: %s (blue) vs. %s (red)',...
+                strrep(sources{1}, '_', '\_'),...
+                strrep(sources{2}, '_', '\_')));
+axis equal;
+set(gca, 'YDir', 'Reverse');
+
+subplot(122); % Post-transform comparison
+plot_boundaries(bounds{1}, c1, 'b', sel_ics(:,1), []);
+plot_boundaries(bounds{2}, c2, 'r', sel_ics(:,2), tform);
+title(sprintf('Post-transform: %s (blue) vs. %s (red)',...
+                strrep(sources{1}, '_', '\_'),...
+                strrep(sources{2}, '_', '\_')));
+axis equal;
+set(gca, 'YDir', 'Reverse');
+
+% Transform Source2 masks for output
+mask1_ref = imref2d(size(masks{1}{1}));
+for ic_idx = 1:s2.ica_info.num_ICs
+    masks{2}{ic_idx} = imwarp(masks{2}{ic_idx}, tform,...
+        'OutputView', mask1_ref);
+end
+
+% Prep output
+%------------------------------------------------------------
+masks1 = masks{1};
+masks2 = masks{2};
+
+info.source1 = source_dir1;
+info.source2 = source_dir2;
+info.num_ics_for_alignment = num_ics_for_alignment;
+info.sel_ics = sel_ics;
+info.sel_ics_centers  = sel_ics_centers;
+info.tform = tform;
+
+end % compute_affine_transform
+
+function [boundaries, masks, ic_map] = plot_ic_filters(ica_filters, cl, ic_filter_threshold)
+    % Plot grayscale image of IC filters along with their boundaries
+    num_ics = size(ica_filters,3);
+    boundaries = cell(num_ics, 1);
+    masks = cell(num_ics, 1);
+    
+    ic_map = sum(ica_filters,3);
+    imagesc(ic_map);
+    colormap gray;
+    axis equal;
+    hold on;
+    
+    for ic_idx = 1:num_ics
+        ic_filter = ica_filters(:,:,ic_idx);
+        [boundary, mask] = compute_ic_boundary(ic_filter, ic_filter_threshold);
+        if strcmp(cl{ic_idx}, 'not a cell')
+            color = 'r';
+        else
+            color = 'g';
+        end
+        plot(boundary(:,1), boundary(:,2), color);
+        
+        boundaries{ic_idx} = boundary;
+        masks{ic_idx} = mask;
+    end
+end
+
+function plot_boundaries(boundaries, cl, color, sel_ics, tform)
+    % Plot boundaries as a single color, with an optional transform
+    num_ics = length(cl);
+    for ic_idx = 1:num_ics
+        boundary = boundaries{ic_idx};
+        if ~isempty(tform) % Optional spatial transform
+            boundary = transformPointsForward(tform, boundary);
+        end
+        if ismember(ic_idx, sel_ics) % One of the user-selected ICs
+            fill(boundary(:,1), boundary(:,2), color);
+        else
+            if ~strcmp(cl{ic_idx}, 'not a cell') % Is a cell
+                plot(boundary(:,1), boundary(:,2), color);
+            end
+        end
+        hold on;
+    end
+end
+
+function selected_ic_idx = get_selected_ic_idx(boundaries, click_xy)
+    % Return the first IC index whose filter boundary encloses the
+    %   XY position provided in `click_xy`
+    num_ics = length(boundaries);
+    selected_ic_idx = []; % If no hit, then return empty
+    for ic_idx = 1:num_ics
+        bound = boundaries{ic_idx};
+        if inpolygon(click_xy(1), click_xy(2), bound(:,1), bound(:,2))
+            selected_ic_idx = ic_idx;
+            break;
+        end
+    end
+end

--- a/alignment/compute_affine_transform.m
+++ b/alignment/compute_affine_transform.m
@@ -1,4 +1,4 @@
-function [masks1, masks2, info] = compute_affine_transform(source_dir1, source_dir2)
+function [info, masks1, masks2] = compute_affine_transform(source_dir1, source_dir2)
 % IC map alignment based on user-defined control points.
 %
 % Inputs:
@@ -6,12 +6,12 @@ function [masks1, masks2, info] = compute_affine_transform(source_dir1, source_d
 %       classification (class_*.txt) outputs
 %
 % Outputs:
+%   info: Struct containing results of the affine transformation fit
 %   masks1: Cell array containing thresholded IC masks for source 1
 %   masks2: Cell array containing _transformed_ thresholded IC masks
 %           for source 2. (Note that the image dimensions match the
 %           dimensions of source 1 masks!)
 %
-% Tony Hyun Kim (2015 Feb 26)
 
 num_ics_for_alignment = 3;
 ic_filter_threshold = 0.3;
@@ -41,7 +41,7 @@ title(strrep(sources{2},'_','\_'));
 % Allow the user to select the ICs used in matching
 %------------------------------------------------------------
 sel_colors = 'ybk';
-fprintf('Please select %d ICs from each dataset (in order)\n',...
+fprintf('compute_affine_transform: Please select %d ICs from each dataset (in order)\n',...
     num_ics_for_alignment);
 
 sel_ics = zeros(num_ics_for_alignment,2); % List of selected ICs
@@ -66,7 +66,7 @@ while (~all(sel_ics_idx == num_ics_for_alignment))
                  sel_colors(mod(sel_idx,length(sel_colors))+1));
 
             props = regionprops(masks{source_idx}{ic_idx},'centroid');
-            fprintf('%s: IC %d selected (at [%.1f %.1f])!\n',...
+            fprintf('  %s: IC %d selected (at [%.1f %.1f])!\n',...
                 sources{source_idx}, ic_idx,...
                 props.Centroid(1), props.Centroid(2));
             
@@ -74,11 +74,11 @@ while (~all(sel_ics_idx == num_ics_for_alignment))
             sel_ics_idx(source_idx) = sel_idx;
             sel_ics_centers(sel_idx,:,source_idx) = props.Centroid;
         else
-            fprintf('  No more ICs needed from %s!\n',...
+            fprintf('  %s: No more ICs needed!\n',...
                 sources{source_idx});
         end
     else % No hit
-        fprintf('  No IC detected at cursor (%s)!\n',...
+        fprintf('  %s: No IC detected at cursor!\n',...
             sources{source_idx});
     end
 end
@@ -126,6 +126,7 @@ info.source2 = source_dir2;
 info.num_ics1 = s1.ica_info.num_ICs;
 info.num_ics2 = s2.ica_info.num_ICs;
 info.num_ics_for_alignment = num_ics_for_alignment;
+info.ic_filter_threshold = ic_filter_threshold;
 info.sel_ics = sel_ics;
 info.sel_ics_centers  = sel_ics_centers;
 info.tform = tform;

--- a/alignment/compute_affine_transform.m
+++ b/alignment/compute_affine_transform.m
@@ -58,7 +58,7 @@ while (~all(sel_ics_idx == num_ics_for_alignment))
     end
     
     ic_idx = get_selected_ic_idx(bounds{source_idx}, click_xy);
-    if ~isempty(ic_idx)
+    if ~isempty(ic_idx) % Hit
         sel_idx = sel_ics_idx(source_idx) + 1;
         if (sel_idx <= num_ics_for_alignment)
             fill(bounds{source_idx}{ic_idx}(:,1),...
@@ -77,7 +77,7 @@ while (~all(sel_ics_idx == num_ics_for_alignment))
             fprintf('  No more ICs needed from %s!\n',...
                 sources{source_idx});
         end
-    else
+    else % No hit
         fprintf('  No IC detected at cursor (%s)!\n',...
             sources{source_idx});
     end
@@ -123,6 +123,8 @@ masks2 = masks{2};
 
 info.source1 = source_dir1;
 info.source2 = source_dir2;
+info.num_ics1 = s1.ica_info.num_ICs;
+info.num_ics2 = s2.ica_info.num_ICs;
 info.num_ics_for_alignment = num_ics_for_alignment;
 info.sel_ics = sel_ics;
 info.sel_ics_centers  = sel_ics_centers;

--- a/alignment/run_alignment.m
+++ b/alignment/run_alignment.m
@@ -1,0 +1,81 @@
+function [match_1to2, match_2to1, info] = run_alignment(ic_source_dir1, ic_source_dir2)
+% Align two sets of IC filters.
+%
+% Inputs:
+%   ic_source_dirX: Directory name that contains the ICA filter/trace pairs
+%       ("ica_*.mat") and classification results ("class_*.txt")
+%
+% Outputs:
+%   match_XtoY: Cell that contains mapping information from source X to
+%       source Y.
+%
+%       For example, match_1to2{k} is a [Nx2] matrix where N is the number
+%       of ICs from source 2 that match IC k of source 1. The first column
+%       of the matrix is the index of the matching IC in source 2; the
+%       second column is the overlap score between the IC pairs.
+%
+% Example usage:
+%   [m1to2, m2to1] = run_alignment('c9m7d07_ica001', 'c9m7d08_ica001');
+%
+% Control point-based registration of two sets of ICs
+%------------------------------------------------------------
+fprintf('run_alignment: Beginning alignment of %s and %s\n',...
+    ic_source_dir1, ic_source_dir2);
+[affine_info, masks1, masks2] = compute_affine_transform(ic_source_dir1, ic_source_dir2);
+
+% Compute matrix of mask overlaps
+%   Note that the overlap matrix is non-symmetric!
+%------------------------------------------------------------
+input('run_alignment: Press any key to continue with mask matching >> ');
+M = zeros(affine_info.num_ics1, affine_info.num_ics2);
+for i = 1:affine_info.num_ics1
+    if (mod(i,20)==0)
+        fprintf('  %s: Computing overlaps (%.1f%%)...\n',...
+            datestr(now), 100*i/affine_info.num_ics1);
+    end
+    for j = 1:affine_info.num_ics2
+        M(i,j) = compute_mask_overlap(masks1{i}, masks2{j});
+    end
+end
+fprintf('  %s: Overlap matrix completed!\n', datestr(now));
+
+% Find the nonzero elements of the mask overlap matrix
+%------------------------------------------------------------
+overlap_threshold = 1/3;
+match_1to2 = cell(affine_info.num_ics1,1);
+for i = 1:affine_info.num_ics1
+    m = M(i,:);
+    matching_js = find(m>overlap_threshold);
+    if isempty(matching_js)
+        match_1to2{i} = [];
+    else
+        matching_overlaps = m(matching_js);
+        match_1to2{i} = [matching_js' matching_overlaps']; % [j overlap]
+        match_1to2{i} = sortrows(match_1to2{i},2); % Sort by overlap
+        match_1to2{i} = flipud(match_1to2{i}); % Descending
+    end
+end
+
+match_2to1 = cell(affine_info.num_ics2,1); % Same in the opposite direction
+for j = 1:affine_info.num_ics2
+    m = M(:,j)';
+    matching_is = find(m>overlap_threshold);
+    if isempty(matching_is)
+        match_2to1{j} = [];
+    else
+        matching_overlaps = m(matching_is);
+        match_2to1{j} = [matching_is' matching_overlaps'];
+        match_2to1{j} = sortrows(match_2to1{j},2);
+        match_2to1{j} = flipud(match_2to1{j});
+    end
+end
+
+% Set up auxiliary output
+%------------------------------------------------------------
+info.ic_source1 = ic_source_dir1;
+info.ic_source2 = ic_source_dir2;
+info.affine = affine_info;
+info.masks1 = masks1;
+info.masks2 = masks2;
+info.overlap_threshold = overlap_threshold;
+info.overlap_matrix = M;

--- a/alignment/run_alignment.m
+++ b/alignment/run_alignment.m
@@ -21,7 +21,7 @@ function [match_1to2, match_2to1, info] = run_alignment(ic_source_dir1, ic_sourc
 %------------------------------------------------------------
 fprintf('run_alignment: Beginning alignment of %s and %s\n',...
     ic_source_dir1, ic_source_dir2);
-[affine_info, masks1, masks2] = compute_affine_transform(ic_source_dir1, ic_source_dir2);
+[affine_info, masks1, masks2_tform] = compute_affine_transform(ic_source_dir1, ic_source_dir2);
 
 % Compute matrix of mask overlaps
 %   Note that the overlap matrix is non-symmetric!
@@ -34,7 +34,7 @@ for i = 1:affine_info.num_ics1
             datestr(now), 100*i/affine_info.num_ics1);
     end
     for j = 1:affine_info.num_ics2
-        M(i,j) = compute_mask_overlap(masks1{i}, masks2{j});
+        M(i,j) = compute_mask_overlap(masks1{i}, masks2_tform{j});
     end
 end
 fprintf('  %s: Overlap matrix completed!\n', datestr(now));
@@ -76,6 +76,6 @@ info.ic_source1 = ic_source_dir1;
 info.ic_source2 = ic_source_dir2;
 info.affine = affine_info;
 info.masks1 = masks1;
-info.masks2 = masks2;
+info.masks2 = masks2_tform;
 info.overlap_threshold = overlap_threshold;
 info.overlap_matrix = M;

--- a/image_op/compute_ic_boundary.m
+++ b/image_op/compute_ic_boundary.m
@@ -1,0 +1,16 @@
+function [boundary, ic_mask] = compute_ic_boundary(ic_filter, ic_filter_thresh)
+% Computes the boundary of the IC filter
+
+A = threshold_ic_filter(ic_filter, ic_filter_thresh);
+
+ic_mask = (A>0);
+boundaries = bwboundaries(ic_mask, 'noholes');
+boundary = boundaries{1};
+for i = 2:length(boundaries)
+    new_boundary = boundaries{i};
+    if (size(new_boundary,1) > size(boundary,1))
+        boundary = new_boundary;
+    end
+end
+
+boundary = fliplr(boundary); % Result arranged as [x y]

--- a/image_op/compute_mask_overlap.m
+++ b/image_op/compute_mask_overlap.m
@@ -1,0 +1,5 @@
+function overlap = compute_mask_overlap(mask1, mask2)
+% Compute the Jacard similarity of two (logical) masks. The two masks
+%   should have the same dimensions.
+
+overlap = nnz(mask1 & mask2) / nnz(mask1 | mask2);


### PR DESCRIPTION
@forea 

First pass implementation of cross-day IC alignment. (Actually, we can use the same script to "align" multiple IC results on the same day as well -- i.e. determine the IC index permutation between runs.)

The top level alignment routine is `run_alignment`. I've set up a directory in `Dropbox/herrin/scripts/20150227_run-alignment` where the script can be run as follows:
```
[m1to2, m2to1] = run_alignment('c9m7d07_ica001', 'c9m7d08_ica001')
```

The order of operation is as follows. First, we ask the user to select 3 ICs from each dataset, which are used as the "control points" in the cross-day IC map registration. The selected ICs are colored in blue-black-yellow, and the colors indicate how the IC pairs will be matched across datasets:
![alignpoints](https://cloud.githubusercontent.com/assets/2081503/6421788/12acf038-be87-11e4-88ee-2e87e99de877.png)

We then compute the affine transformation to map dataset 2 onto dataset 1. The plot below shows the overlap between the two datasets before and after the affine transformation:
![alignmaps](https://cloud.githubusercontent.com/assets/2081503/6421856/9dc4c7f4-be87-11e4-9725-23016a322da9.png)

All of the above occurs within `compute_affine_transform`.

Secondly, we compute the spatial overlap between ICs of dataset 1 and ICs of dataset 2, taking account the affine transformation. The overlap score is computed in `compute_mask_overlap` and is essentially the Jacard overlap of two boolean images.

Finally, the spatial overlap scores (highly sparse matrix) is parsed into a more convenient output format (i.e. `match_1to2` and `match_2to1`).