### PR TITLE
Take screenshots automatically

### DIFF
--- a/classification/classify_ics.m
+++ b/classification/classify_ics.m
@@ -120,6 +120,11 @@ while (ic_idx <= num_ics)
                     class = load_classification(full_file);
                     fprintf('  Loaded classification from "%s"\n', file);
                 end
+            case 't' % "Take" screenshot
+                screenshot_name = sprintf('ic%03d.png', ic_idx);
+                screenshot_name = fullfile(ic_dir, screenshot_name);
+                print('-dpng', screenshot_name);
+                fprintf('  Plot saved to %s\n', screenshot_name);
             otherwise
                 fprintf('  Could not parse "%s"\n', resp);
         end


### PR DESCRIPTION
@forea 

Added an extra option (`t`) to "take screenshot" during `classify_ics`. It allows the user to save trial-phase plots -- like the one attached -- to the ICA directory (e.g. `ica001`).
![ic106](https://cloud.githubusercontent.com/assets/2081503/6424234/9cf0cb1c-bea9-11e4-9147-97b6a3ce53b0.png)
