### PR TITLE
Kimth/count frames

### DIFF
--- a/image_op/compute_movie_scale.m
+++ b/image_op/compute_movie_scale.m
@@ -2,8 +2,8 @@ function clim = compute_movie_scale(M)
 % Compute an appropriate viewing scale (CLim) for the provided movie
 
 [height, width, ~] = size(M);
-maxVec = single(reshape(max(M,[],3), height*width, 1));
-minVec = single(reshape(min(M,[],3), height*width, 1));
+maxVec = reshape(max(M,[],3), height*width, 1);
+minVec = reshape(min(M,[],3), height*width, 1);
 quantsMax = quantile(maxVec,[0.85,0.87,0.9,0.93,0.95]);
 quantsMin = quantile(minVec,[0.85,0.87,0.9,0.93,0.95]);
 clim = [mean(quantsMin),mean(quantsMax)]*1.1;

--- a/image_op/compute_movie_scale.m
+++ b/image_op/compute_movie_scale.m
@@ -2,8 +2,8 @@ function clim = compute_movie_scale(M)
 % Compute an appropriate viewing scale (CLim) for the provided movie
 
 [height, width, ~] = size(M);
-maxVec = reshape(max(M,[],3), height*width, 1);
-minVec = reshape(min(M,[],3), height*width, 1);
+maxVec = single(reshape(max(M,[],3), height*width, 1));
+minVec = single(reshape(min(M,[],3), height*width, 1));
 quantsMax = quantile(maxVec,[0.85,0.87,0.9,0.93,0.95]);
 quantsMin = quantile(minVec,[0.85,0.87,0.9,0.93,0.95]);
 clim = [mean(quantsMin),mean(quantsMax)]*1.1;

--- a/io/count_frames_in_xml.m
+++ b/io/count_frames_in_xml.m
@@ -1,4 +1,4 @@
-function total_frames = count_frames_in_xml(path_to_xml)
+function xml_frames = count_frames_in_xml(path_to_xml)
 % Computes the number of frames contained in all Miniscope XML files
 %   of the specified directory. Gives a warning if the XML file is not
 %   matched by a corresponding RAW or TIF file.
@@ -10,6 +10,7 @@ function total_frames = count_frames_in_xml(path_to_xml)
 
 xml_files = dir(fullfile(path_to_xml,'*.xml'));
 num_files = length(xml_files);
+xml_frames = zeros(num_files,2); % [Regular-frames Dropped-frames]
 fprintf('Found %d XML files in "%s"\n', num_files, path_to_xml);
 
 total_frames = 0;
@@ -21,6 +22,7 @@ for i = 1:num_files
     % Count frames
     num_frames = str2double(xml_struct.frames);
     num_dropped_frames = str2double(xml_struct.dropped_count);
+    xml_frames(i,:) = [num_frames num_dropped_frames];
     
     total_dropped_frames = total_dropped_frames + num_dropped_frames;
     total_frames = total_frames + num_frames + num_dropped_frames;

--- a/io/overwrite_frame_indices.m
+++ b/io/overwrite_frame_indices.m
@@ -1,0 +1,20 @@
+function overwrite_frame_indices(plusmaze_source, new_frame_indices)
+
+% Read in information from the original PlusMaze source
+[~, location_info, time] = parse_plusmaze(plusmaze_source);
+num_trials = length(time);
+
+% Generate a new PlusMaze output
+[path_to, name, ~] = fileparts(plusmaze_source);
+output_name = sprintf('%s_new.txt', name);
+output_name = fullfile(path_to, output_name);
+
+fid = fopen(output_name, 'w');
+for i = 1:num_trials
+    fprintf(fid, '%s %s %s %.3f %d %d %d %d\n',...
+        location_info{i,1}, location_info{i,2}, location_info{i,3},...
+        time(i),...
+        new_frame_indices(i,1), new_frame_indices(i,2),...
+        new_frame_indices(i,3), new_frame_indices(i,4));
+end
+fclose(fid);

--- a/io/overwrite_frame_indices.m
+++ b/io/overwrite_frame_indices.m
@@ -1,4 +1,15 @@
 function overwrite_frame_indices(plusmaze_source, new_frame_indices)
+% Generate a new PlusMaze text file (appends "_new" to the filename)
+%   with a new set of frame indices
+%
+% Inputs:
+%   plusmaze_source: Name of the original text file (trial information
+%       other that frame indices will be taken from this file)
+%   new_frame_indices: [num_trials x 4] matrix where the i-th row indicates
+%       the [start open-gate close-gate end] frames of trial i.
+%
+% Example usage:
+%   overwrite_frame_indices('mouse7_day10_allo-south.txt', frame_indices);
 
 % Read in information from the original PlusMaze source
 [~, location_info, time] = parse_plusmaze(plusmaze_source);

--- a/view/view_movie.m
+++ b/view/view_movie.m
@@ -2,6 +2,7 @@ function view_movie(M, varargin)
 % Displays the frames of a movie matrix M [height x row x num_frames]
 %   (Note: also works with a single image)
 % Optional input will repeat the movie.
+
 if isempty(varargin)
     num_repeats = 1;
 else
@@ -10,9 +11,9 @@ end
 
 num_frames = size(M,3);
 
-if isa(M, 'uint16') % Raw movie
+if isa(M, 'uint16') % Every frame is rescaled for the raw movie
     h = imagesc(M(:,:,1));
-else
+else % Otherwise, use common CLim scaling
     movie_clim = compute_movie_scale(M);
     h = imagesc(M(:,:,1), movie_clim);
 end

--- a/view/view_movie.m
+++ b/view/view_movie.m
@@ -10,8 +10,12 @@ end
 
 num_frames = size(M,3);
 
-movie_clim = compute_movie_scale(M);
-h = imagesc(M(:,:,1), movie_clim);
+if isa(M, 'uint16') % Raw movie
+    h = imagesc(M(:,:,1));
+else
+    movie_clim = compute_movie_scale(M);
+    h = imagesc(M(:,:,1), movie_clim);
+end
 axis image;
 truesize;
 colormap gray;


### PR DESCRIPTION
Few minor changes that I found useful for manually checking the consistency of the PlusMaze text file. (I had to manually fix c9m7d06 text file -- where the FPGA erroneously counted an extra frame.)
- `count_frames_in_xml` explicitly returns a matrix with the number of frames. No other functional change. -- @forea 
- `overwrite_frame_indices` generates a new PlusMaze text file with a new set of frame indices. This way, we don't have to trim and bin the frame indices from scratch each time. -- @jmaxey 
- `view_movie` will _not_ use a common `CLim` for the raw movie (type `uint16`) -- which is not helpful for the raw movie whose brightness fluctuates like crazy. Also, the `quantile` operation in `compute_movie_scale` is not compatible with `uint16`. -- @inanhkn 