### PR TITLE
Added varargout "trial_frames" generated by find_start_end_of_trials

### DIFF
--- a/behavior/MouseTracking/FindTrials/mouse_path_plotter.m
+++ b/behavior/MouseTracking/FindTrials/mouse_path_plotter.m
@@ -33,7 +33,7 @@ function [trial_frames] = mouse_path_plotter( movie, centroids_mat, varargin)
     
     figure;
     
-    for trial_idx = 1:length(trial_frames)
+    for trial_idx = 1:size(trial_frames,1)
         trial_start = trial_frames(trial_idx,1);
         trial_end = trial_frames(trial_idx,2);
         scrollsubplot(5,6,trial_idx)

--- a/behavior/MouseTracking/FindTrials/mouse_path_plotter.m
+++ b/behavior/MouseTracking/FindTrials/mouse_path_plotter.m
@@ -1,4 +1,4 @@
-function mouse_path_plotter( movie, centroids_mat, varargin)
+function [varargout] = mouse_path_plotter( movie, centroids_mat, varargin)
 % Plots the path of the mouse during each trial based on position data and
 % trial frames (either specified by plusmaze txt or extracted from movie
 % using find_start_end_of_trials)
@@ -7,6 +7,10 @@ function mouse_path_plotter( movie, centroids_mat, varargin)
 %     movie: Behavior video
 %     centroids_mat: position data from get_mouse_XY_pos
 %     varargin: plusmaze txt file, e.g. 'mouse7_day09_allo-south.txt'
+% 
+% Optional Output:
+%     trial_frames: if no plusmaze source, can return trial_frames generated
+%         by find_start_end_of_trials
 % 
 % 2015-03-01 Fori Wang
 
@@ -18,6 +22,7 @@ function mouse_path_plotter( movie, centroids_mat, varargin)
     else
         % if no plusmaze source, find trial start and ends from movie
         [trial_frames,~]=find_start_end_of_trials(centroids_mat);
+        varargout{1} = trial_frames;
     end
     
     % load centroids

--- a/behavior/MouseTracking/FindTrials/mouse_path_plotter.m
+++ b/behavior/MouseTracking/FindTrials/mouse_path_plotter.m
@@ -1,4 +1,4 @@
-function [varargout] = mouse_path_plotter( movie, centroids_mat, varargin)
+function [trial_frames] = mouse_path_plotter( movie, centroids_mat, varargin)
 % Plots the path of the mouse during each trial based on position data and
 % trial frames (either specified by plusmaze txt or extracted from movie
 % using find_start_end_of_trials)
@@ -8,7 +8,7 @@ function [varargout] = mouse_path_plotter( movie, centroids_mat, varargin)
 %     centroids_mat: position data from get_mouse_XY_pos
 %     varargin: plusmaze txt file, e.g. 'mouse7_day09_allo-south.txt'
 % 
-% Optional Output:
+% Output:
 %     trial_frames: if no plusmaze source, can return trial_frames generated
 %         by find_start_end_of_trials
 % 
@@ -22,7 +22,6 @@ function [varargout] = mouse_path_plotter( movie, centroids_mat, varargin)
     else
         % if no plusmaze source, find trial start and ends from movie
         [trial_frames,~]=find_start_end_of_trials(centroids_mat);
-        varargout{1} = trial_frames;
     end
     
     % load centroids


### PR DESCRIPTION
Small change to mouse_path_plotter code to also spit out trial_frames from behavior movie if no plusmaze data was provided (i.e. function had to figure out trial_frames on its own)