### PR TITLE
Reduce images to 3d to save time

### DIFF
--- a/behavior/MouseTracking/get_mouse_XY_pos.m
+++ b/behavior/MouseTracking/get_mouse_XY_pos.m
@@ -75,8 +75,9 @@ function [ centroids ] = get_mouse_XY_pos( movie, varargin )
     
     % setup background image: average of 5000 frames
     bg_vid = read(behavior_vid,[1 5000]);
-%     bg_vid = squeeze(bg_vid(:,:,1,:)); % 3D movie stack
-    bg_image = mean(bg_vid,4);
+    bg_vid = squeeze(bg_vid(:,:,1,:)); % 3D movie stack
+%     bg_image = mean(bg_vid,4);
+    bg_image = mean(bg_vid,3);
     bg_image = uint8(bg_image);
     
     c_old = [0 0];
@@ -89,13 +90,14 @@ function [ centroids ] = get_mouse_XY_pos( movie, varargin )
         % read in all of the frames for the trial at the beginning
         frame_range = frame_chunks(idx,:);
         video = read(behavior_vid,frame_range);
-%         video = squeeze(video(:,:,1,:)); % 3D movie stack
+        video = squeeze(video(:,:,1,:)); % 3D movie stack
         
         if display_tracking
             
             % plot original image on the left
             subplot(121);
-            image = video(:,:,:,1);
+%             image = video(:,:,:,1);
+            image = video(:,:,1);
             h = imagesc(image);
             title(sprintf('Original: Frames %d - %d',...
                           frame_chunks(idx,1), frame_chunks(idx,2)));
@@ -117,11 +119,12 @@ function [ centroids ] = get_mouse_XY_pos( movie, varargin )
             l = plot(0,0,'k*');
         end
 
-        for frame_idx = 1:size(video,4)
+%         for frame_idx = 1:size(video,4)
+        for frame_idx = 1:size(video,3)
            
            % Update original image CData
-            image = video(:,:,:,frame_idx);
-%             image = im2double(image,'indexed');
+%             image = video(:,:,:,frame_idx);
+            image = video(:,:,frame_idx);
             if display_tracking
                 set(h,'CData',image);
                 pause(0.00001);


### PR DESCRIPTION
Uses `squeeze` to reduce videos to 3D instead of 4D. Compared results to 4D tracker, and centroids are identical. Cuts the time approx. in half.