### PR TITLE
Kimth/day summary

### DIFF
--- a/io/DaySummary.m
+++ b/io/DaySummary.m
@@ -1,0 +1,81 @@
+classdef DaySummary
+% Summary of PlusMaze data for a single day.
+%
+% Inputs:
+%   plusmaze_txt: Name of the PlusMaze output text file. Frame indices of
+%       the text file needs to be consistent with the ICA traces!
+%   ica_dir: Directory containing 
+%       - ICA results in a "ica_*.mat" file
+%       - Classification results in a "class_*.txt" file
+%
+% Output:
+%   DaySummary object
+%
+% Example usage:
+%   ds = DaySummary('c9m7d06_ti2.txt', 'ica001');
+%
+    properties
+        cells
+        trials
+        
+        num_cells
+        num_trials
+        
+        trial_indices
+    end
+    
+    methods
+        function obj = DaySummary(plusmaze_txt, ica_dir, varargin)
+            % Load data
+            %------------------------------------------------------------
+            [trial_indices, loc_info, trial_durations] =...
+                parse_plusmaze(plusmaze_txt);
+            
+            data = load(get_most_recent_file(ica_dir, 'ica_*.mat'));
+            
+            % Parse trial data
+            %------------------------------------------------------------
+            exclude_probe_trials = 0;
+            for k = 1:length(varargin)
+                switch lower(varargin{k})
+                    case 'excludeprobe'
+                        exclude_probe_trials = 1;
+                end
+            end
+            
+            if (exclude_probe_trials)
+                is_probe = strcmp(loc_info(:,1), 'north') | ...
+                           strcmp(loc_info(:,1), 'south');
+                       
+                trial_indices = trial_indices(~is_probe,:);
+                loc_info = loc_info(~is_probe,:);
+                trial_durations = trial_durations(~is_probe);
+            end
+            
+            obj.trial_indices = trial_indices;
+            obj.num_trials = size(trial_indices, 1);
+            traces = cell(obj.num_trials, 1);
+            for k = 1:obj.num_trials
+                trial_frames = trial_indices(k,1):...
+                               trial_indices(k,end);
+                traces{k} = data.ica_traces(trial_frames, :)';
+            end
+            
+            obj.trials = struct(...
+                'start', loc_info(:,1),...
+                'goal',  loc_info(:,2),...
+                'end',   loc_info(:,3),...
+                'time',  num2cell(trial_durations),...
+                'traces', traces);
+            
+            % Parse cell data
+            %------------------------------------------------------------
+            obj.num_cells = data.ica_info.num_ICs;
+            
+            class = load_classification(get_most_recent_file(ica_dir, 'class_*.txt'));
+            obj.cells = struct(...
+                'im', squeeze(num2cell(data.ica_filters, [1 2])),...
+                'label', class);
+        end
+    end
+end

--- a/io/DaySummary.m
+++ b/io/DaySummary.m
@@ -26,15 +26,7 @@ classdef DaySummary
     
     methods
         function obj = DaySummary(plusmaze_txt, ica_dir, varargin)
-            % Load data
-            %------------------------------------------------------------
-            [trial_indices, loc_info, trial_durations] =...
-                parse_plusmaze(plusmaze_txt);
-            
-            data = load(get_most_recent_file(ica_dir, 'ica_*.mat'));
-            
-            % Parse trial data
-            %------------------------------------------------------------
+            % Handle optional input
             exclude_probe_trials = 0;
             for k = 1:length(varargin)
                 switch lower(varargin{k})
@@ -43,6 +35,16 @@ classdef DaySummary
                 end
             end
             
+            % Load data
+            %------------------------------------------------------------
+            [trial_indices, loc_info, trial_durations] =...
+                parse_plusmaze(plusmaze_txt);
+            
+            data = load(get_most_recent_file(ica_dir, 'ica_*.mat'));
+            
+            % Parse trial data
+            %   TODO: Bring in centroids corresponding to mouse position
+            %------------------------------------------------------------
             if (exclude_probe_trials)
                 is_probe = strcmp(loc_info(:,1), 'north') | ...
                            strcmp(loc_info(:,1), 'south');
@@ -52,15 +54,16 @@ classdef DaySummary
                 trial_durations = trial_durations(~is_probe);
             end
             
-            obj.trial_indices = trial_indices;
-            obj.num_trials = size(trial_indices, 1);
-            traces = cell(obj.num_trials, 1);
-            for k = 1:obj.num_trials
+            num_trials = size(trial_indices, 1);
+            traces = cell(num_trials, 1);
+            for k = 1:num_trials
                 trial_frames = trial_indices(k,1):...
                                trial_indices(k,end);
                 traces{k} = data.ica_traces(trial_frames, :)';
             end
             
+            obj.num_trials = num_trials;
+            obj.trial_indices = trial_indices;
             obj.trials = struct(...
                 'start', loc_info(:,1),...
                 'goal',  loc_info(:,2),...
@@ -76,6 +79,12 @@ classdef DaySummary
             obj.cells = struct(...
                 'im', squeeze(num2cell(data.ica_filters, [1 2])),...
                 'label', class);
+        end
+        
+        function [trace, frame_indices] = get_cell_trial(obj, cell_idx, trial_idx)
+            trace = obj.trials(trial_idx).traces(cell_idx,:);
+            frame_indices = obj.trial_indices(trial_idx,1):...
+                            obj.trial_indices(trial_idx,end);
         end
     end
 end

--- a/utils/get_most_recent_file.m
+++ b/utils/get_most_recent_file.m
@@ -1,10 +1,13 @@
 function filename = get_most_recent_file(path_to, pattern)
-
 % Usage:
 %   get_most_recent_file('ica001', 'ica_*.mat')
 
 files = dir(fullfile(path_to, pattern));
-datenums = files.datenum;
-[~, sorted] = sort(datenums);
 
-filename = fullfile(path_to, files(sorted(1)).name);
+filename = '';
+if ~isempty(files)
+    datenums = files.datenum;
+    [~, sorted] = sort(datenums);
+
+    filename = fullfile(path_to, files(sorted(1)).name);
+end


### PR DESCRIPTION
@inanhkn This is a re-implementation of PR #51 where the "summary" is implemented as an object.

The summary object can be instantiated as follows:
```
>> ds = DaySummary('_data/c9m7d06_ti2.txt', 'ica001', 'excludeprobe')

ds = 

  DaySummary with properties:

            cells: [250x1 struct]
           trials: [100x1 struct]
        num_cells: 250
       num_trials: 100
    trial_indices: [100x4 int32]
```
The first argument to the constructor is the PlusMaze text file, where the frame indices contained in the text file should be consistent with the ICA traces. The second argument to the constructor is the ICA directory, which should contain the ICA result (`ica_*.mat`) and the classification result (`class_*.txt`).

In the near future, we should augment `DaySummary` to take in also the mouse positions within each trial.

Once the object has been returned (as `ds`, in this example). You can check if the variable is of a `DaySummary` type:
```
>> isa(ds, 'DaySummary')

ans =

     1
```
This type-checking ability should allow us to build visualization / analysis functions that take in `DaySummary` objects.

You can also access trial information as follows:
```
>> ds.trials(4)

ans = 

     start: 'east'
      goal: 'south'
       end: 'south'
      time: 24.6150
    traces: [250x236 single]

>> ds.trials(4).start

ans =

east
```

You can access the trace of trial `k` and IC index `m` as follows: `ds.trials(k).traces(m,:)`, which is similar to your access pattern in #51. However, for convenience I also added a convenience method that allows you to retrieve the same trace by: `ds.get_cell_trace(m, k)`.

An aside: one key difference between an object and a struct is that the former allows you to associate functions (like `get_cell_trace`) -- called "methods" -- with the object. This is in contrast to structs which does not have that capability.