### PR TITLE
Factor out trial filtering

### DIFF
--- a/io/DaySummary.m
+++ b/io/DaySummary.m
@@ -131,24 +131,35 @@ classdef DaySummary
             ylabel('Signal [a.u.]');
         end
         
-        function plot_superposed_trials(obj, cell_idx, varargin)
-            % Optional arguments allow for filtering of trials, e.g.
-            %   "plot_superposed_trials(cell_idx, 'start', 'east')"
-            display_trial = ones(obj.num_trials, 1);
+        function filtered_trials = filter_trials(obj, varargin)
+            filtered_trials = ones(1, obj.num_trials);
             for k = 1:length(varargin)
                 vararg = varargin{k};
                 if ischar(vararg)
                     switch lower(vararg)
                         case 'incorrect'
-                            display_trial = ~strcmp({obj.trials.goal}, {obj.trials.end});
+                            filtered_trials = filtered_trials &...
+                                (~strcmp({obj.trials.goal}, {obj.trials.end}));
                         case 'correct'
-                            display_trial = strcmp({obj.trials.goal}, {obj.trials.end});
+                            filtered_trials = filtered_trials &...
+                                strcmp({obj.trials.goal}, {obj.trials.end});
                         case 'start'
-                            display_trial = strcmp({obj.trials.start}, varargin{k+1});
+                            filtered_trials = filtered_trials &...
+                                strcmp({obj.trials.start}, varargin{k+1});
                         case 'end'
-                            display_trial = strcmp({obj.trials.end}, varargin{k+1});
+                            filtered_trials = filtered_trials &...
+                                strcmp({obj.trials.end}, varargin{k+1});
                     end
                 end
+            end
+        end
+        
+        function plot_superposed_trials(obj, cell_idx, varargin)
+            % Optional arguments allow for filtering of trials, e.g.
+            %   "plot_superposed_trials(cell_idx, 'start', 'east')"
+            display_trial = ones(obj.num_trials, 1);
+            if ~isempty(varargin)
+                display_trial = varargin{1};
             end
             
             trace_min = Inf;
@@ -187,24 +198,12 @@ classdef DaySummary
             % Optional arguments allow for filtering of trials, e.g.
             %   "plot_cell_raster(cell_idx, 'start', 'east')"
             display_trial = ones(obj.num_trials, 1);
-            for k = 1:length(varargin)
-                vararg = varargin{k};
-                if ischar(vararg)
-                    switch lower(vararg)
-                        case 'incorrect'
-                            display_trial = ~strcmp({obj.trials.goal}, {obj.trials.end});
-                        case 'correct'
-                            display_trial = strcmp({obj.trials.goal}, {obj.trials.end});
-                        case 'start'
-                            display_trial = strcmp({obj.trials.start}, varargin{k+1});
-                        case 'end'
-                            display_trial = strcmp({obj.trials.end}, varargin{k+1});
-                    end
-                end
+            if ~isempty(varargin)
+                display_trial = varargin{1};
             end
                         
             resample_grid = linspace(0, 1, 1000);
-            raster = zeros(obj.num_trials, length(resample_grid));            
+            raster = zeros(sum(display_trial), length(resample_grid));            
             counter = 0;
             for k = 1:obj.num_trials
                 if display_trial(k)
@@ -215,8 +214,7 @@ classdef DaySummary
                                       resample_grid,...
                                       'pchip');
                 end
-            end            
-            raster(all(~raster,2), : ) = []; %remove empty rows
+            end
             
             imagesc(resample_grid, 1:size(raster,1), raster);
             xlabel('Trial phase [a.u.]');


### PR DESCRIPTION
Factored out the trial filtering used in `plot_cell_raster` and `plot_superposed_trials`. Each of these methods now accept as its `varargin` a logical vector that indicates which trials to display.

There is a new method `filter_trials` that produces the logical vector. Specifically, what used to be
```
ds = DaySummary(...);
ds.plot_cell_raster(cell_idx, 'start', 'west');
```
is now performed as:
```
ds.plot_cell_raster(cell_idx, ds.filter_trials(`start`, `west`));
```

Note that `filter_trials` can apply multiple filters. For example `ds.filter_trials(`start`, `west`, `correct`)` will return the trials that start from the west arm _and_ the mouse correctly navigated to the goal arm.