### PR TITLE
Kimth/trial filter

### DIFF
--- a/io/DaySummary.m
+++ b/io/DaySummary.m
@@ -160,7 +160,7 @@ classdef DaySummary
             %   "plot_superposed_trials(cell_idx, 'start', 'east')"
             display_trial = ones(obj.num_trials, 1);
             if ~isempty(varargin)
-                display_trial = obj.filter_trials(varargin);
+                display_trial = obj.filter_trials(varargin{:});
             end
             
             trace_min = Inf;
@@ -200,7 +200,7 @@ classdef DaySummary
             %   "plot_cell_raster(cell_idx, 'start', 'east')"
             display_trial = ones(obj.num_trials, 1);
             if ~isempty(varargin)
-                display_trial = obj.filter_trials(varargin);
+                display_trial = obj.filter_trials(varargin{:});
             end
                         
             resample_grid = linspace(0, 1, 1000);

--- a/io/DaySummary.m
+++ b/io/DaySummary.m
@@ -152,6 +152,7 @@ classdef DaySummary
                     end
                 end
             end
+            filtered_trials = filtered_trials';
         end
         
         function plot_superposed_trials(obj, cell_idx, varargin)
@@ -159,7 +160,7 @@ classdef DaySummary
             %   "plot_superposed_trials(cell_idx, 'start', 'east')"
             display_trial = ones(obj.num_trials, 1);
             if ~isempty(varargin)
-                display_trial = varargin{1};
+                display_trial = obj.filter_trials(varargin);
             end
             
             trace_min = Inf;
@@ -199,7 +200,7 @@ classdef DaySummary
             %   "plot_cell_raster(cell_idx, 'start', 'east')"
             display_trial = ones(obj.num_trials, 1);
             if ~isempty(varargin)
-                display_trial = varargin{1};
+                display_trial = obj.filter_trials(varargin);
             end
                         
             resample_grid = linspace(0, 1, 1000);


### PR DESCRIPTION
This brings back the syntax `ds.plot_cell_raster(cell_idx, 'start', 'east')`, which is more succinct.