### PR TITLE
fix baseline in reconstructed traces

### DIFF
--- a/classification/support/view_cell_interactively.m
+++ b/classification/support/view_cell_interactively.m
@@ -12,7 +12,7 @@ time = 1/fps*((1:length(trace))-1);
 
 % Some parameters
 ic_filter_threshold = 0.3; % For generating the IC filter outline
-mad_scale = 5; % Used for coarse detection of activity in the IC trace
+mad_scale = 10; % Used for coarse detection of activity in the IC trace
 active_frame_padding = 5*fps; % Use 100 for 20 Hz movie
 time_window = 100/fps; % Width of running window
 

--- a/image_op/reconstruct_traces.m
+++ b/image_op/reconstruct_traces.m
@@ -145,10 +145,17 @@ end
 info.num_pairs = rec_filter_count; %#ok<STRNU>
 filters = filters(:,:,1:rec_filter_count);
 
+cells_to_exclude = [];
 for cell_idx = 1:rec_filter_count % Normalize
     filter = filters(:,:,cell_idx);
-    filters(:,:,cell_idx) = filter / sum(filter(:));
+    sum_filter = sum(filter(:));
+    if sum_filter>0
+        filters(:,:,cell_idx) = filter / sum_filter;
+    else
+        cells_to_exclude(end+1) = cell_idx;
+    end
 end
+filters(:,:,cells_to_exclude) = []; 
 
 % Reconstruct traces
 %------------------------------------------------------------

--- a/image_op/reconstruct_traces.m
+++ b/image_op/reconstruct_traces.m
@@ -1,4 +1,5 @@
-function reconstruct_traces(movie_source, ica_dir, varargin)
+%function reconstruct_traces(movie_source, ica_dir, varargin)
+
 % Reconstruct trace from the movie using the IC filters.
 %
 % inputs:
@@ -32,7 +33,7 @@ function reconstruct_traces(movie_source, ica_dir, varargin)
 %
 
 % Reconstruction parameters
-threshMov = -1; % By default keep everything
+threshMov = 0; 
 threshIC = 0.3;
 
 if ~isempty(varargin)
@@ -151,6 +152,7 @@ end
 
 % Reconstruct traces
 %------------------------------------------------------------
+
 fprintf('%s: Loading movie...\n', datestr(now));
 M = load_movie(movie_source);
 [height, width, num_frames] = size(M);
@@ -171,7 +173,11 @@ for cell_idx = 1:rec_filter_count
     pix_active = find(rec_filter>0);
     movie_portion = M(pix_active,:)';
     movie_portion(movie_portion<threshMov) = 0;
-    traces(:,cell_idx) = movie_portion * rec_filter(pix_active);  
+    trace_this = (movie_portion * rec_filter(pix_active))';  
+    % Fix baseline
+    h = polyfit(1:num_frames,min(trace_this,2*quantile(trace_this,0.3)),1);
+    subst = h(2)+h(1)*(1:num_frames);
+    traces(:,cell_idx) = trace_this-subst;
 end
 
 % Save the result to mat file

--- a/image_op/reconstruct_traces.m
+++ b/image_op/reconstruct_traces.m
@@ -1,4 +1,4 @@
-%function reconstruct_traces(movie_source, ica_dir, varargin)
+function reconstruct_traces(movie_source, ica_dir, varargin)
 
 % Reconstruct trace from the movie using the IC filters.
 %

--- a/image_op/reconstruct_traces.m
+++ b/image_op/reconstruct_traces.m
@@ -36,7 +36,7 @@ function reconstruct_traces(movie_source, ica_dir, varargin)
 min_num_pixels = 4;
 
 % Reconstruction parameters
-threshMov = 0; 
+threshMov = -1; 
 threshIC = 0.3;
 
 if ~isempty(varargin)
@@ -145,7 +145,6 @@ for ic_idx = 1:num_ICs
         end
     end
 end
-info.num_pairs = rec_filter_count; %#ok<STRNU>
 filters = filters(:,:,1:rec_filter_count);
 
 cells_to_exclude = [];
@@ -159,6 +158,8 @@ for cell_idx = 1:rec_filter_count % Normalize
     end
 end
 filters(:,:,cells_to_exclude) = []; 
+rec_filter_count = rec_filter_count - length(cells_to_exclude);
+info.num_pairs = rec_filter_count;%#ok<STRNU>
 
 % Reconstruct traces
 %------------------------------------------------------------
@@ -184,10 +185,7 @@ for cell_idx = 1:rec_filter_count
     movie_portion = M(pix_active,:)';
     movie_portion(movie_portion<threshMov) = 0;
     trace_this = (movie_portion * rec_filter(pix_active))';  
-    % Fix baseline
-    h = polyfit(1:num_frames,min(trace_this,2*quantile(trace_this,0.3)),1);
-    subst = h(2)+h(1)*(1:num_frames);
-    traces(:,cell_idx) = trace_this-subst;
+    traces(:,cell_idx) = fix_baseline(trace_this);
 end
 
 % Save the result to mat file

--- a/image_op/reconstruct_traces.m
+++ b/image_op/reconstruct_traces.m
@@ -32,6 +32,9 @@ function reconstruct_traces(movie_source, ica_dir, varargin)
 % Hakan Inan (Mar 15)
 %
 
+% Minimum number of active pixels in an IC filter to be regarded as valid
+min_num_pixels = 4;
+
 % Reconstruction parameters
 threshMov = 0; 
 threshIC = 0.3;
@@ -149,10 +152,10 @@ cells_to_exclude = [];
 for cell_idx = 1:rec_filter_count % Normalize
     filter = filters(:,:,cell_idx);
     sum_filter = sum(filter(:));
-    if sum_filter>0
+    if sum_filter>0 && sum(filter(:)>0)>=min_num_pixels
         filters(:,:,cell_idx) = filter / sum_filter;
     else
-        cells_to_exclude(end+1) = cell_idx;
+        cells_to_exclude(end+1) = cell_idx; 
     end
 end
 filters(:,:,cells_to_exclude) = []; 

--- a/signal_op/fix_baseline.m
+++ b/signal_op/fix_baseline.m
@@ -1,0 +1,8 @@
+function trace_out = fix_baseline(trace_in)
+% Remove baseline offset of cell trace by fitting a line to it and
+% subtracting
+
+num_frames = length(trace_in);
+h = polyfit(1:num_frames,min(trace_this,2*quantile(trace_in,0.3)),1);
+subst = h(2)+h(1)*(1:num_frames);
+trace_out = trace_in-subst;


### PR DESCRIPTION
Fixed the baseline offset and trend in the reconstructed traces. Refer to the below picture for the improvement.
![untitled](https://cloud.githubusercontent.com/assets/5778377/7051723/38f91dee-dddf-11e4-81dc-ee60d70de0b9.jpg)

@kimtonyhyun  I think you need to tell me once more what I need to modify to fix the NaNs in the filters. Is it the line where the filters are normalized? And if yes, how can the sum of an ICA filter be zero?