### PR TITLE
better method for baseline removal

### DIFF
--- a/signal_op/fix_baseline.m
+++ b/signal_op/fix_baseline.m
@@ -1,4 +1,4 @@
-function trace_out = fix_baseline(trace_in)
+% function trace_out = fix_baseline(trace_in)
 % Remove baseline offset of cell trace with following steps:
 %    - sample baseline for overlapping small segments
 %    - smooth baseline samples
@@ -9,6 +9,8 @@ function trace_out = fix_baseline(trace_in)
     k = 100; % Sampling period
     s = 1000; % Sample size
     c = 0.15; % scale for the smoothing filter length
+    
+    if size(trace_in,1)==1,trace_in=trace_in';end % make input a column vector
     
     % Sample baseline at uniformly spaced points
     num_frames = length(trace_in);
@@ -35,7 +37,12 @@ function trace_out = fix_baseline(trace_in)
     end
 
     % Interpolate the sample baseline points
-    subt = interp1(baselines(:,1),filt_out,(1:num_frames)');
+    subt = interp1(baselines(:,1),filt_out,(1:num_frames)','spline');
 
     trace_out = trace_in-subt;
 
+    
+    plot(trace_in)
+    hold on
+    plot(subt)
+    hold off

--- a/signal_op/fix_baseline.m
+++ b/signal_op/fix_baseline.m
@@ -1,8 +1,41 @@
 function trace_out = fix_baseline(trace_in)
-% Remove baseline offset of cell trace by fitting a line to it and
-% subtracting
+% Remove baseline offset of cell trace with following steps:
+%    - sample baseline for overlapping small segments
+%    - smooth baseline samples
+%    - interpolate samples to 1:length(trace) to get the time varying
+%      baseline estimate
+%    - subtract baseline estimate from the trace
 
-num_frames = length(trace_in);
-h = polyfit(1:num_frames,min(trace_in,2*quantile(trace_in,0.3)),1);
-subst = h(2)+h(1)*(1:num_frames);
-trace_out = trace_in-subst;
+    k = 100; % Sampling period
+    s = 1000; % Sample size
+    c = 0.15; % scale for the smoothing filter length
+    
+    % Sample baseline at uniformly spaced points
+    num_frames = length(trace_in);
+    num_samples = floor(num_frames/k);
+    baselines = zeros(num_samples,2);
+    for idx_sample = 0:num_samples-1    
+        idx_begin = max(1,1+idx_sample*k-s/2);
+        idx_end = min(num_frames,idx_sample*k+s/2);
+        tr = trace_in(idx_begin:idx_end);
+        % Baseline estimate is the most frequent bin in the histogram
+        [counts,centers] = hist(tr,20);
+        baseline = centers(find(counts==max(counts),1));
+        baselines(idx_sample+1,:) = [1+idx_sample*k,baseline];
+    end
+
+    % Smooth the baseline values with moving average filter
+    filt_hlen = floor(num_samples*c/2);% Half-length of the filter
+    filt_out = zeros(num_samples,1);
+    for idx_sample = 0:num_samples-1 % Manual convolution (due to edge effects)   
+        idx_begin = max(1,1+idx_sample-filt_hlen);
+        idx_end = min(num_samples,idx_sample+filt_hlen+1);
+        b = baselines(idx_begin:idx_end,2);
+        filt_out(idx_sample+1) = mean(b);
+    end
+
+    % Interpolate the sample baseline points
+    subt = interp1(baselines(:,1),filt_out,(1:num_frames)');
+
+    trace_out = trace_in-subt;
+

--- a/signal_op/fix_baseline.m
+++ b/signal_op/fix_baseline.m
@@ -1,4 +1,4 @@
-% function trace_out = fix_baseline(trace_in)
+function trace_out = fix_baseline(trace_in)
 % Remove baseline offset of cell trace with following steps:
 %    - sample baseline for overlapping small segments
 %    - smooth baseline samples


### PR DESCRIPTION
After observing remaining baseline fluctuations in many traces, I wrote a better routine for the baseline removal. It is simple, but requires a bit more computation. Refer to the function for the details.
Here are some examples to visualize the improvement: (the blue traces are the ones obtained after baseline removal with the old procedure, orange traces are the fitted baselines with the new routine.)
![1](https://cloud.githubusercontent.com/assets/5778377/7149877/04f5d224-e2c8-11e4-8b6d-d152da575ed0.jpg)
![6](https://cloud.githubusercontent.com/assets/5778377/7149879/0d4b75aa-e2c8-11e4-92ea-972eba207f91.jpg)
![7](https://cloud.githubusercontent.com/assets/5778377/7149882/12d1ffbc-e2c8-11e4-8876-94662605a227.jpg)


