### PR TITLE
Medfilt for removing hot pixels

### DIFF
--- a/image_op/medfilt_movie.m
+++ b/image_op/medfilt_movie.m
@@ -1,0 +1,84 @@
+function medfilt_movie(movie_in, movie_out, varargin)
+% Apply median filtering from file ('movie_in') to file ('movie_out').
+% Optional argument specifies the half-width of the median filter.
+%
+% If 'movie_out' is left as an empty string, then default name will be
+% provided.
+%
+% The medfilt parameters will also be saved in the output HDF5 file under
+% the '/Medfilt' directory
+%
+% Inputs:
+%   movie_in:  Name of incoming HDF5 movie
+%   movie_out: Name of outgoing HDF5 movie
+%
+% Example usage:
+%   norm_movie('c9m7d12.hdf5','',15);
+%
+if isempty(movie_out)
+    [~, name] = fileparts(movie_in);
+    movie_out = sprintf('%s_med.hdf5', name);
+    fprintf('medfilt_movie: Output movie will be saved as "%s"\n', movie_out);
+end
+
+% Default dataset name for the movie
+movie_dataset = '/Data/Images';
+
+% Grab the movie parameters
+[movie_size, in_data_type] = get_dataset_info(movie_in, movie_dataset);
+height = movie_size(1);
+width = movie_size(2);
+num_frames = movie_size(3);
+
+% Begin medfilt processing
+%------------------------------------------------------------
+medfilt_halfwidth = 1;
+if ~isempty(varargin)
+    medfilt_halfwidth = varargin{1};
+end
+
+medfilt_neighborhood = (1+2*medfilt_halfwidth)*[1 1];
+
+% Prepare output movie
+output_height = height - 2*medfilt_halfwidth;
+output_width  = width  - 2*medfilt_halfwidth;
+h5create(movie_out, movie_dataset,...
+         [output_height, output_width, num_frames],...
+         'Datatype', in_data_type);
+     
+copy_hdf5_params(movie_in, movie_out);
+
+h5create(movie_out, '/Medfilt/HalfWidth', 1, 'Datatype', 'int16');
+h5write(movie_out, '/Medfilt/HalfWidth', int16(medfilt_halfwidth));
+
+% Apply medfilt
+frame_chunk_size = 1000;
+[frame_chunks, num_chunks] = make_frame_chunks(num_frames, frame_chunk_size);
+
+for i = 1:num_chunks
+    fprintf('%s: Applying medfilt on frames %d to %d (out of %d)...\n',...
+        datestr(now), frame_chunks(i,1), frame_chunks(i,2), num_frames);
+    
+    chunk_start = frame_chunks(i,1);
+    chunk_count = frame_chunks(i,2) - frame_chunks(i,1) + 1;
+    
+    movie_chunk = h5read(movie_in, movie_dataset,...
+                         [1 1 chunk_start],...
+                         [height width chunk_count]);
+    
+    movie_chunk_med = zeros(output_height, output_width, chunk_count, in_data_type);
+    
+    for frame_idx = 1:size(movie_chunk,3)
+        frame = movie_chunk(:,:,frame_idx);
+        frame_med = medfilt2(frame, medfilt_neighborhood);
+        
+        movie_chunk_med(:,:,frame_idx) = frame_med((1+medfilt_halfwidth):(end-medfilt_halfwidth),...
+                                                   (1+medfilt_halfwidth):(end-medfilt_halfwidth));
+    end
+    
+    h5write(movie_out, movie_dataset,...
+        movie_chunk_med,...
+        [1 1 chunk_start],...
+        [output_height output_width chunk_count]);
+end
+fprintf('%s: Done!\n', datestr(now));

--- a/image_op/norm_movie.m
+++ b/image_op/norm_movie.m
@@ -6,8 +6,8 @@ function norm_movie(movie_in, movie_out, varargin)
 % If 'movie_out' is left as an empty string, then default name will be
 % provided.
 %
-% The cropping parameters will also be saved in the output HDF5 file under
-% the '/Norm' directory
+% The normalization parameters will also be saved in the output HDF5 file
+% under the '/Norm' directory
 %
 % Inputs:
 %   movie_in:  Name of incoming HDF5 movie


### PR DESCRIPTION
The function `medfilt_movie` performs 2D median filtering on a frame-by-frame basis in order to eliminate hot pixels. The syntax is the same as the other file-to-file preprocessing functions, i.e. `medfilt_movie(movie_in, movie_out)`.

The motivation comes from Cohort 9 Mouse 2. For whatever reason, this particular microscope has a tremendous number of hot pixels in the camera. (An aside @forea, we should get this fixed by Inscopix.)

The hot pixels are stationary with respect to the camera which means that, following motion correction, these pixels move around, giving rise to artifactual ICs. For c9m2, my current idea is to apply median filtering right after concatenation.

The effect of median filtering can be seen here: [medfilt_demo.mat (400 MB)](https://www.dropbox.com/s/n1guzcwx4tw5p13/medfilt_demo.mat?dl=0)

When you load `medfilt_demo.mat` into the Matlab workspace, you'll find two movie snippets from c9m2: `M` and `M_medfilt`. The first movie is the raw concatenated input to `medfilt_movie` and the latter is the output. You can view these snippets as usual via `view_movie(M, 'repeat', 5)`. It should be evident that some very obvious hot pixels are eliminated by the median filtering.