### PR TITLE
Issue warning on dropped filters

### DIFF
--- a/image_op/reconstruct_traces.m
+++ b/image_op/reconstruct_traces.m
@@ -157,6 +157,9 @@ for cell_idx = 1:rec_filter_count % Normalize
         cells_to_exclude(end+1) = cell_idx; 
     end
 end
+fprintf('%s: Eliminated %d filters based on minimum size requirement\n',...
+    datestr(now), length(cells_to_exclude));
+
 filters(:,:,cells_to_exclude) = []; 
 rec_filter_count = rec_filter_count - length(cells_to_exclude);
 info.num_pairs = rec_filter_count;%#ok<STRNU>


### PR DESCRIPTION
@inanhkn Simple change -- `reconstruct_traces` displays the number of filters that has been dropped due to the size requirement. I had been wondering why I was losing so many ICs.