### PR TITLE
Kimth/turns

### DIFF
--- a/io/DaySummary.m
+++ b/io/DaySummary.m
@@ -287,6 +287,9 @@ classdef DaySummary
                         case 'end'
                             filtered_trials = filtered_trials &...
                                 strcmp({obj.trials.end}, varargin{k+1});
+                        case 'turn'
+                            filtered_trials = filtered_trials &...
+                                strcmp({obj.trials.turn}, varargin{k+1});
                     end
                 end
             end


### PR DESCRIPTION
With this PR, when `DaySummary` is initially loaded, it will compute the turn executed by the mouse on each trial. For example:

```
>> ds = DaySummary(sources.maze, 'ica001_rec01', 'reconst');
20-Apr-2015 09:41:15: Loaded data from ica001_rec01\rec_150418-180332.mat
>> ds.trials(1)

ans = 

     start: 'east'
      goal: 'south'
       end: 'south'
      turn: 'left'
      time: 24.7720
    traces: [237x238 single]
```

We can also filter the raster plots in terms of the turn, i.e.:
```
>> ds.plot_cell_raster(135,'turn','left');
```
yields a raster plot that keeps only trials in which the mouse turned left:
![raster_turn](https://cloud.githubusercontent.com/assets/2081503/7235260/de70624e-e741-11e4-9127-bff9a2faf5ce.png)
