### PR TITLE
Kimth/threshold

### DIFF
--- a/classification/support/view_cell_interactively.m
+++ b/classification/support/view_cell_interactively.m
@@ -74,46 +74,7 @@ thresh = mad_scale * mad;
 [active_periods, num_active_periods] =...
     parse_active_frames(trace > thresh, active_frame_padding);
 
-% Prepare global trace
-subplot(3,3,[1 2 3]);
-plot(time, trace, 'b');
-hold on;
-plot(x_range, thresh*[1 1], 'r--'); % Display threshold
-for period_idx = 1:num_active_periods
-    active_period = active_periods(period_idx, :);
-    active_frames = active_period(1):active_period(2);
-    plot(time(active_frames), trace(active_frames), 'r');
-    text(double(time(active_frames(1))),... % 'text' fails on single
-         double(y_range(2)),...
-         num2str(period_idx),...
-         'Color', 'r',...
-         'VerticalAlignment', 'top');
-end
-xlim(x_range);
-ylim(y_range);
-t1 = plot(time(1)*[1 1], y_range, 'k'); % Time indicator
-xlabel('Time [s]');
-ylabel('Signal [a.u.]');
-hold off;
-
-% Prepare running trace
-a = subplot(3,3,[6 9]);
-plot(time, trace, 'b');
-hold on;
-for period_idx = 1:num_active_periods
-    active_period = active_periods(period_idx, :);
-    active_frames = active_period(1):active_period(2);
-    plot(time(active_frames), trace(active_frames), 'r');
-end
-xlim([0 time_window]);
-ylim(y_range);
-t2 = plot(time(1)*[1 1], y_range, 'k'); % Time indicator
-d = plot(time(1), trace(1), 'or',...
-            'MarkerFaceColor', 'r',...
-            'MarkerSize', 12); % Dot
-xlabel('Time [s]');
-ylabel('Signal [a.u.]');
-hold off;
+setup_traces();
 
 % Interaction loop:
 %   Display the user-specified active period
@@ -186,9 +147,56 @@ while (1)
     val = str2double(resp);
 end
 
-    % Display subroutine. Note that frames are mean subtracted!
+    % Display subroutines
     %------------------------------------------------------------
+    function setup_traces()
+        global t1 t2 a d;
+        
+        % Prepare global trace
+        subplot(3,3,[1 2 3]);
+        plot(time, trace, 'b');
+        hold on;
+        plot(x_range, thresh*[1 1], 'r--'); % Display threshold
+        for period_idx = 1:num_active_periods
+            active_period = active_periods(period_idx, :);
+            active_frames = active_period(1):active_period(2);
+            plot(time(active_frames), trace(active_frames), 'r');
+            text(double(time(active_frames(1))),... % 'text' fails on single
+                 double(y_range(2)),...
+                 num2str(period_idx),...
+                 'Color', 'r',...
+                 'VerticalAlignment', 'top');
+        end
+        xlim(x_range);
+        ylim(y_range);
+        t1 = plot(time(1)*[1 1], y_range, 'k'); % Time indicator
+        xlabel('Time [s]');
+        ylabel('Signal [a.u.]');
+        hold off;
+
+        % Prepare running trace
+        a = subplot(3,3,[6 9]);
+        plot(time, trace, 'b');
+        hold on;
+        for period_idx = 1:num_active_periods
+            active_period = active_periods(period_idx, :);
+            active_frames = active_period(1):active_period(2);
+            plot(time(active_frames), trace(active_frames), 'r');
+        end
+        xlim([0 time_window]);
+        ylim(y_range);
+        t2 = plot(time(1)*[1 1], y_range, 'k'); % Time indicator
+        d = plot(time(1), trace(1), 'or',...
+                    'MarkerFaceColor', 'r',...
+                    'MarkerSize', 12); % Dot
+        xlabel('Time [s]');
+        ylabel('Signal [a.u.]');
+        hold off;
+    end % setup_traces
+    
     function display_active_period(selected_indices)
+        global t1 t2 a d;
+        
         for selected_idx = selected_indices
             frames = active_periods(selected_idx,1):...
                      active_periods(selected_idx,2);

--- a/classification/support/view_cell_interactively.m
+++ b/classification/support/view_cell_interactively.m
@@ -71,9 +71,8 @@ y_range = y_range + 0.1*y_delta*[-1 1];
 mad = compute_mad(trace);
 thresh = mad_scale * mad;
 
-active_periods = parse_active_frames(trace > thresh,...
-                                     active_frame_padding);
-num_active_periods = size(active_periods, 1);
+[active_periods, num_active_periods] =...
+    parse_active_frames(trace > thresh, active_frame_padding);
 
 % Prepare global trace
 subplot(3,3,[1 2 3]);
@@ -224,7 +223,7 @@ end
 
 end % main function
 
-function active_frames = parse_active_frames(binary_trace, half_width)
+function [active_frames, num_active] = parse_active_frames(binary_trace, half_width)
 % Segment the active portions of a binary trace into intervals
 
     if (half_width > 0)
@@ -261,6 +260,7 @@ function active_frames = parse_active_frames(binary_trace, half_width)
     end
 
     active_frames = reshape(active_frames, 2, length(active_frames)/2)';
+    num_active = size(active_frames, 1);
 end
 
 function filter_out = rescale_filter_to_clim(filter, clim)

--- a/io/DaySummary.m
+++ b/io/DaySummary.m
@@ -88,6 +88,7 @@ classdef DaySummary
             class_source = get_most_recent_file(ica_dir, 'class_*.txt');
             if ~isempty(class_source)
                 class = load_classification(class_source);
+                fprintf('  %s: Loaded classification from %s\n', datestr(now), class_source);
                 assert(length(class)==obj.num_cells,...
                        sprintf('Number of labels in %s is not consistent with %s!',...
                                class_source, data_source));

--- a/io/DaySummary.m
+++ b/io/DaySummary.m
@@ -52,7 +52,7 @@ classdef DaySummary
             end
             data = load(data_source);
             obj.num_cells = data.info.num_pairs;
-            fprintf('%s: Loaded data from %s\n', datestr(now), data_source);
+            fprintf('  %s: Loaded data from %s\n', datestr(now), data_source);
             
             % Parse trial data
             %   TODO: Bring in centroids corresponding to mouse position
@@ -92,7 +92,7 @@ classdef DaySummary
                        sprintf('Number of labels in %s is not consistent with %s!',...
                                class_source, data_source));
             else % No classification file
-                fprintf('%s: No classification file in %s!\n', datestr(now), ica_dir);
+                fprintf('  %s: No classification file in %s!\n', datestr(now), ica_dir);
                 class = cell(obj.num_cells,1); % Empty
             end
 


### PR DESCRIPTION
With this PR, we have the ability to redefine the threshold during `classify_ics`. Previously, we've had cases where the hard-coded threshold was too high, and therefore one couldn't view the movie during classification.

Here's how it goes. First, start up `classify_ics` as usual:
```
>> sources = data_sources

sources = 

         maze: '_data/c9m7d18_ti2.txt'
    miniscope: '_data/c9m7d18_cr_mc_cr_norm_dff_ti2.hdf5'
          pca: '_data/pca_n500.mat'
          fps: 10

>> M = classify_cells(sources, 'rec_18', 'reconst');
  25-Apr-2015 19:19:02: Loading "_data/c9m7d18_cr_mc_cr_norm_dff_ti2.hdf5" to memory...
  25-Apr-2015 19:20:02: Done!
  25-Apr-2015 19:20:10: Movie will be displayed with fixed CLim = [-0.037 0.049]...
  25-Apr-2015 19:20:11: Loaded data from rec_18\rec_new.mat
  25-Apr-2015 19:20:13: Loaded filters/traces from "rec_18"
Classifier (1/240) >> c
Cell viewer >> 
```

At this point, for c9m7d18, I see the following plot:
![c9m7d18_cell1_before](https://cloud.githubusercontent.com/assets/2081503/7331093/3ace4eac-eab7-11e4-8c11-e86c27997ce9.png)

A new option within "Cell viewer" is now `t` (for threshold):
```
Classifier (1/240) >> c
Cell viewer >> t
  Please select a new threshold on the global trace
```

The script then asks you to click on the "global" trace. This is the subplot that shows the entire trace from beginning to end (i.e. the topmost subplot).

For example, in this example, you can raise the threshold to exclude the little spikes:
![c9m7d18_cell1_after](https://cloud.githubusercontent.com/assets/2081503/7331109/cbe79236-eab7-11e4-9675-82c944f3cead.png)

After the selection of the new threshold, control returns as usual:
```
Cell viewer >> t
  Please select a new threshold on the global trace
  New threshold value of 0.015 selected!
Cell viewer >> 
```