### PR TITLE
added LS

### DIFF
--- a/image_op/reconstruct_traces.m
+++ b/image_op/reconstruct_traces.m
@@ -201,11 +201,14 @@ else
     F = reshape(filters,height*width,rec_filter_count);
     idx_nonzero = find(sum(F,2)>0);
     F_small = F(idx_nonzero,:); 
-    proj_F = (F_small'*F_small)\F_small';
-
-    for idx_frame = 1:num_frames
-        traces(idx_frame,:) = fix_baseline( proj_F *M(idx_nonzero,idx_frame) );
+    
+    % Caution: Below line requires memory of size roughly 10-20% of M
+    traces = (F_small'*F_small)\(F_small'*M(idx_nonzero,:)); 
+    traces = traces';
+    for k = 1:rec_filter_count;
+        traces(:,k) = fix_baseline(traces(:,k));
     end
+
 end
 
 

--- a/image_op/reconstruct_traces.m
+++ b/image_op/reconstruct_traces.m
@@ -194,7 +194,6 @@ if use_legacy
         movie_portion = M(pix_active,:)';
         movie_portion(movie_portion<threshMov) = 0;
         trace_this = (movie_portion * rec_filter(pix_active))';  
-        traces(:,cell_idx) = fix_baseline(trace_this);
     end
 else
     %Least Squares Method
@@ -205,12 +204,12 @@ else
     % Caution: Below line requires memory of size roughly 10-20% of M
     traces = (F_small'*F_small)\(F_small'*M(idx_nonzero,:)); 
     traces = traces';
-    for k = 1:rec_filter_count;
-        traces(:,k) = fix_baseline(traces(:,k));
-    end
-
 end
 
+% Remove baseline fluctuations
+for k = 1:rec_filter_count;
+    traces(:,k) = fix_baseline(traces(:,k));
+end
 
 % Save the result to mat file
 %------------------------------------------------------------


### PR DESCRIPTION
This PR deals with the addition of the Least Squares reconstruction of the traces from the movie and the filters. The script now reconstruct traces by using least squares by default. Call it with the extra parameter `use_legacy` to perform applying mask to the movie for extraction.

More explicitly, this example call results in LS extraction:
`reconstruct_traces('c9m7d08_cr_mc_cr_norm_dff_ti2.hdf5','')`

This one results in extraction by applying mask:
`reconstruct_traces('c9m7d08_cr_mc_cr_norm_dff_ti2.hdf5','','use_legacy')`