### PR TITLE
Allow for programmatic specification of crop bounds

### DIFF
--- a/image_op/crop_movie.m
+++ b/image_op/crop_movie.m
@@ -44,11 +44,17 @@ x_bounds = [];
 y_bounds = [];
 if ~isempty(varargin)
     for k = 1:length(varargin)
-        switch lower(varargin{k})
-            case 'trim' % Trim borders
-                trim = varargin{k+1};
-                x_bounds = [1+trim width-trim];
-                y_bounds = [1+trim height-trim];
+        if ischar(varargin{k})
+            switch lower(varargin{k})
+                case 'trim' % Trim borders
+                    trim = varargin{k+1};
+                    x_bounds = [1+trim width-trim];
+                    y_bounds = [1+trim height-trim];
+                case 'bounds' % Specify [x_bounds y_bounds]
+                    bounds = varargin{k+1};
+                    x_bounds = bounds(1:2);
+                    y_bounds = bounds(3:4);
+            end
         end
     end
 end


### PR DESCRIPTION
When cropping a movie, can explicitly specify `[x_min x_max y_min y_max]` to denote the crop region (rather than dragging a rectangle).

This makes it easy to apply the exact same cropping window to multiple movies, e.g. successive days of the same animal.

Usage: `crop_movie('c11m2d08.hdf5', '', 'bounds', [10 500 50 600])`.