### PR TITLE
Check that file exists before reconstruct

### DIFF
--- a/image_op/reconstruct_traces.m
+++ b/image_op/reconstruct_traces.m
@@ -60,6 +60,10 @@ if ~isempty(varargin)
     end
 end
 
+% Check that the movie file exists
+assert(~isempty(dir(movie_source)),...
+       sprintf('Movie file %s not found!', movie_source));
+
 % Load ICA
 ica_filename = get_most_recent_file(ica_dir, 'ica_*.mat');
 ica = load(ica_filename);


### PR DESCRIPTION
Check that the movie file is spelled correctly at the beginning of `reconstruct_traces`. Otherwise, the manual specification of the ROIs (from each IC) goes to waste.