### PR TITLE
Kimth/count tif frames

### DIFF
--- a/io/concatenateHDF5.m
+++ b/io/concatenateHDF5.m
@@ -27,6 +27,8 @@ function concatenateHDF5(tifDir,outputDir,hdf5Name,downsmpFactor,plusmazeName,tr
 startFrames = frame_indices(:,1);
 
 list = dir(fullfile(tifDir,'*.tif'));
+num_files = length(list);
+
 firstName = fullfile(tifDir,list(1).name);
 [rows,cols] = size(imread(firstName));
 
@@ -45,7 +47,7 @@ badTrial = 0;
 testFrames = startFrames(1,1);
 trialCount = 0;
 
-for i=1:length(list)
+for i=1:num_files
     if(i ~= 1)
         %%% Find if the start frame of the next recording matches one of
         %%% the start frame indicies
@@ -73,7 +75,9 @@ for i=1:length(list)
         end
     end
 
-    if(~badTrial)
+    if (badTrial)
+        fprintf('  %d: File "%s" skipped\n', i, list(i).name);
+    else
         %%% Add the good trial to the hdf5 file
         trialCount = trialCount+1;
         tifName = fullfile(tifDir,list(i).name);
@@ -151,7 +155,7 @@ for i=1:length(list)
         h5write(fullfile(outputDir,hdf5Name),'/TrialInfo/Locations',locData,[trialCount,1],[1,3]);
         h5write(fullfile(outputDir,hdf5Name),'/TrialInfo/Time',time(trialCount),[trialCount,1],[1,1]);
         
-        fprintf('File %d of %d stored\n',i,size(list,1));
+        fprintf('  %d: File "%s" stored\n', i, list(i).name);
         
         %%% Total frame count stored in hdf5 file
         totalFrames = totalFrames+numFrames;

--- a/io/miniscope/count_frames_in_tif.m
+++ b/io/miniscope/count_frames_in_tif.m
@@ -1,4 +1,4 @@
-function total_frames = count_frames_in_tif(path_to_tif)
+function tif_frames = count_frames_in_tif(path_to_tif)
 % Computes the number of frames contained in all TIF files of
 %   the specified directory
 %
@@ -11,6 +11,8 @@ tif_files = dir(fullfile(path_to_tif,'*.tif'));
 num_files = length(tif_files);
 fprintf('Found %d TIF files in "%s"\n', num_files, path_to_tif);
 
+tif_frames = zeros(num_files, 1);
+
 total_frames = 0;
 for i = 1:num_files
     tif_filename = fullfile(path_to_tif,tif_files(i).name);
@@ -19,6 +21,7 @@ for i = 1:num_files
     num_frames = length(tif_info);
     total_frames = total_frames + num_frames;
     
+    tif_frames(i) = num_frames;
     fprintf('  %d: "%s" has %d frames\n',...
         i, tif_filename, num_frames);
 end


### PR DESCRIPTION
Minor change to the console output of `concatenateHDF5`, and `count_frames_in_tif` which now returns a vector of tif frame lengths per file. The latter is needed for synchronization debugging.