### PR TITLE
add trimming of pixels

### DIFF
--- a/pca_ica/run_pca.m
+++ b/pca_ica/run_pca.m
@@ -12,7 +12,7 @@ function run_pca(movie_source, num_PCs,varargin)
 %       values.
 %
 % Example usage:
-%   run_pca('c9m7d25_dff.hdf5', 500,1);
+%   run_pca('c9m7d25_dff.hdf5', 500,'trim');
 %
 
 % Defaults
@@ -58,10 +58,11 @@ pca_info.movie_width  = width;
 pca_info.movie_frames = num_frames;
 pca_info.num_PCs = num_PCs; 
 pca_info.trimmed = do_trim; %#ok<STRNU>
-save(savename, 'pca_info', 'pca_filters', 'pca_traces', 'S');
 
 if do_trim
-    save(savename,'idx_kept');
+    save(savename,'pca_info', 'pca_filters', 'pca_traces', 'S','idx_kept');
+else
+    save(savename, 'pca_info', 'pca_filters', 'pca_traces', 'S');
 end
 
 fprintf('%s: All done!\n', datestr(now));

--- a/pca_ica/run_pca.m
+++ b/pca_ica/run_pca.m
@@ -57,7 +57,7 @@ pca_info.movie_height = height;
 pca_info.movie_width  = width;
 pca_info.movie_frames = num_frames;
 pca_info.num_PCs = num_PCs; 
-pca_info.trimmed = do_trim; %#ok<STRNU>
+pca_info.is_trimmed = do_trim; %#ok<STRNU>
 
 if do_trim
     save(savename,'pca_info', 'pca_filters', 'pca_traces', 'S','idx_kept');

--- a/pca_ica/run_pca.m
+++ b/pca_ica/run_pca.m
@@ -22,8 +22,7 @@ do_trim = 0;
 medfilt = 0;
 
 if ~isempty(varargin)
-    len = length(varargin);
-    for k = 1:len
+    for k = 1:length(varargin)
         switch varargin{k}
             case 'trim'
                 do_trim = 1;

--- a/pca_ica/run_pca.m
+++ b/pca_ica/run_pca.m
@@ -83,8 +83,13 @@ pca_info.movie_height = height;
 pca_info.movie_width  = width;
 pca_info.movie_frames = num_frames;
 pca_info.num_PCs = num_PCs; 
+
 pca_info.is_trimmed = do_trim; 
-pca_info.is_medianfiltered = do_medfilt; %#ok<STRNU>
+
+pca_info.is_medianfiltered = do_medfilt;  %#ok<*STRNU>
+if do_medfilt
+    pca_info.medfilt_halfwidth = medfilt_halfwidth;
+end
 
 if do_trim
     save(savename,'pca_info', 'pca_filters', 'pca_traces', 'S','idx_kept');

--- a/pca_ica/run_pca.m
+++ b/pca_ica/run_pca.m
@@ -1,4 +1,4 @@
-function run_pca(movie_source, num_PCs)
+function run_pca(movie_source, num_PCs,varargin)
 % Runs PCA factorization of the movie provided in `movie_source`. Saves the
 % result to 'pca_(...).mat' file.
 %
@@ -6,23 +6,46 @@ function run_pca(movie_source, num_PCs)
 %   movie_source: Movie filename
 %   num_PCs: Number of requested PCs
 %
-% Example usage:
-%   run_pca('c9m7d25_dff.hdf5', 500);
+% Variable input arguments:
+%   'trim': if added as an argument then the script trims pixels in the 
+%       movie that do not cross above the median of the maximum pixel 
+%       values.
 %
+% Example usage:
+%   run_pca('c9m7d25_dff.hdf5', 500,1);
+%
+
+% Defaults
+do_trim = 0;
+
+if ~isempty(varargin)
+    len = length(varargin);
+    for k = 1:len
+        switch varargin{k}
+            case 'trim'
+                do_trim = 1;
+        end
+    end
+end
+
 
 fprintf('%s: Loading %s...\n', datestr(now), movie_source);
 M = load_movie(movie_source);
 [height, width, num_frames] = size(M);
 
-% Make each frame zero-mean in place
-% fprintf('%s: Frame-by-frame normalization of movie...\n', datestr(now));
-% F = compute_mean_fluorescence(M);
-% F = reshape(F,1,1,num_frames);
-% M = bsxfun(@minus, M, F);
-
 % Reshape movie into [space x time] matrix
 num_pixels = height * width;
 M = reshape(M, num_pixels, num_frames);
+
+% Make each frame zero-mean in place
+mean_M = mean(M,1);
+M = bsxfun(@minus, M, mean_M);
+
+if do_trim
+    max_proj = max(M,[],2);
+    idx_kept = find(max_proj>median(max_proj));
+    M = M(idx_kept,:);  %#ok<FNDSB>
+end
 
 % PCA
 %------------------------------------------------------------
@@ -33,7 +56,12 @@ savename = sprintf('pca_n%d.mat', num_PCs);
 pca_info.movie_height = height;
 pca_info.movie_width  = width;
 pca_info.movie_frames = num_frames;
-pca_info.num_PCs = num_PCs; %#ok<STRNU>
+pca_info.num_PCs = num_PCs; 
+pca_info.trimmed = do_trim; %#ok<STRNU>
 save(savename, 'pca_info', 'pca_filters', 'pca_traces', 'S');
+
+if do_trim
+    save(savename,'idx_kept');
+end
 
 fprintf('%s: All done!\n', datestr(now));

--- a/pca_ica/run_pca.m
+++ b/pca_ica/run_pca.m
@@ -39,10 +39,6 @@ fprintf('%s: Loading %s...\n', datestr(now), movie_source);
 M = load_movie(movie_source);
 [height, width, num_frames] = size(M);
 
-% Reshape movie into [space x time] matrix
-num_pixels = height * width;
-M = reshape(M, num_pixels, num_frames);
-
 % Median filter the movie
 if do_medfilt
     
@@ -62,6 +58,9 @@ if do_medfilt
     
 end
 
+% Reshape movie into [space x time] matrix
+num_pixels = height * width;
+M = reshape(M, num_pixels, num_frames);
 
 % Make each frame zero-mean in place
 mean_M = mean(M,1);

--- a/pca_ica/run_pca.m
+++ b/pca_ica/run_pca.m
@@ -1,4 +1,4 @@
-function run_pca(movie_source, num_PCs,varargin)
+function run_pca(movie_source, num_PCs, varargin)
 % Runs PCA factorization of the movie provided in `movie_source`. Saves the
 % result to 'pca_(...).mat' file.
 %
@@ -11,8 +11,7 @@ function run_pca(movie_source, num_PCs,varargin)
 %       movie that do not cross above the median of the maximum pixel 
 %       values.
 %   'medfilt': Add it as an argument to perform median-filtering on the 
-%       movie on a per-frame basis before PCA. Highly recommended since
-%       especially the miniscope camera might have various artifacts.
+%       movie on a per-frame basis before PCA. 
 %
 % Example usage:
 %   run_pca('c9m7d25_dff.hdf5', 500,'trim','medfilt');
@@ -66,6 +65,7 @@ M = reshape(M, num_pixels, num_frames);
 mean_M = mean(M,1);
 M = bsxfun(@minus, M, mean_M);
 
+idx_kept = 1:num_pixels;
 if do_trim
     max_proj = max(M,[],2);
     idx_kept = find(max_proj>median(max_proj));
@@ -83,17 +83,18 @@ pca_info.movie_width  = width;
 pca_info.movie_frames = num_frames;
 pca_info.num_PCs = num_PCs; 
 
-pca_info.is_trimmed = do_trim; 
+pca_info.trim.enabled = do_trim; 
+pca_info.trim.idx_kept = idx_kept;
 
-pca_info.is_medianfiltered = do_medfilt;  %#ok<*STRNU>
+pca_info.medfilt.enabled = do_medfilt;  %#ok<*STRNU>
 if do_medfilt
-    pca_info.medfilt_halfwidth = medfilt_halfwidth;
+    pca_info.medfilt.halfwidth = medfilt_halfwidth;
 end
 
-if do_trim
-    save(savename,'pca_info', 'pca_filters', 'pca_traces', 'S','idx_kept');
-else
-    save(savename, 'pca_info', 'pca_filters', 'pca_traces', 'S');
-end
+% Save only the diagonal of S
+S = diag(S);
+
+save(savename, 'pca_info', 'pca_filters', 'pca_traces', 'S');
+
 
 fprintf('%s: All done!\n', datestr(now));


### PR DESCRIPTION
This PR introduces a new proposed feature for PCA computation, namely trimming of pixels in the movie that are not active.  You can call `run_pca` now as

`run_pca('movie source', #of PCs,'trim');`

To have the script trim half of the movie pixels (ones whose maximums are lower than the median of the max projection image) prior to computing PCA. Assuming that cells occupy less than half of the frame pixels this is an OK way to get rid of pixels. (I have even observed increase in the quality of cell extraction output by eliminating pixels, possibly due to removing the already not-so-relevant variance)

The pixels indices that are kept are stored in the output `.mat` file as the variable `idx_kept`. Whether trimming is done to a `pca*.mat` file can be seen by checking a new property `is_trimmed` under the variable `pca_info`.

This feature speeds up covariance matrix calculation prior to PCA and also ultimately reduces the computation in a subsequent cell extraction step.