### PR TITLE
Kimth/prairie

### DIFF
--- a/io/load_prairie_tif.m
+++ b/io/load_prairie_tif.m
@@ -1,0 +1,19 @@
+function M = load_prairie_tif(path_to_tif)
+% Prairie saves frames of a series as separate TIF files, where each file
+% contains exactly one image. This loader simply enumerates all TIF files
+% in a given directory, and return the result as a single movie matrix.
+%
+% Usage:
+%   M = load_prairie_tif(pwd);
+%
+
+files = dir(fullfile(path_to_tif, '*.tif'));
+num_frames = length(files);
+
+% Open one image to get the X, Y dimensions
+A = imread(files(1).name);
+M = zeros(size(A,1), size(A,2), num_frames, class(A));
+
+for i = 1:num_frames
+    M(:,:,i) = imread(files(i).name);
+end

--- a/view/view_movie.m
+++ b/view/view_movie.m
@@ -26,17 +26,21 @@ end
 
 num_frames = size(M,3);
 
-if (rescale_each_frame || isa(M, 'uint16'))
-    % Every frame is rescaled for the raw movie
-    h = imagesc(M(:,:,1));
-    mask_val = 0; % FIXME
-else % Otherwise, use common CLim scaling
-    if isempty(movie_clim)
-        movie_clim = compute_movie_scale(M);
-    end
-    mask_val = movie_clim(1);
+if ~isempty(movie_clim) % If CLim is provided, use it
     h = imagesc(M(:,:,1), movie_clim);
+else
+    if (rescale_each_frame || isa(M, 'uint16'))
+        % Raw movies (e.g. uint16) are rescaled by default
+        h = imagesc(M(:,:,1));
+        mask_val = 0; % FIXME
+    else % Otherwise, use common CLim scaling
+        movie_clim = compute_movie_scale(M);
+        mask_val = movie_clim(1);
+        h = imagesc(M(:,:,1), movie_clim);
+    end
 end
+
+
 axis image;
 truesize;
 colormap gray;


### PR DESCRIPTION
Added `load_prairie_tif`, for loading 2p movies from the Prairie.

Also streamlined the `CLim` logic in `view_movie`.