### PR TITLE
Kimth/classify commands

### DIFF
--- a/classification/classify_cells.m
+++ b/classification/classify_cells.m
@@ -89,30 +89,13 @@ while (cell_idx <= num_candidates)
                                     M, sources.fps, movie_clim);
                 resp2 = input(sprintf('  Confirm classification ("%s") >> ', resp), 's');
                 resp2 = lower(strtrim(resp2));
-                if (strcmp(resp, resp2))
-                    switch (resp2)
-                        case 'p'
-                            class{cell_idx} = 'phase-sensitive cell';
-                        case 'c'
-                            class{cell_idx} = 'cell';
-                    end
-                    fprintf('  Trace %d classified as %s\n', cell_idx, class{cell_idx});
+                if (strcmp(resp, resp2)) % Confirmed
+                    set_label(cell_idx, resp2);
                     cell_idx = cell_idx + 1;
                 end
 
-            case {'p!', 'c!'} % Classify without viewing trace
-                switch resp(1)
-                    case 'p'
-                        class{cell_idx} = 'phase-sensitive cell';
-                    case 'c'
-                        class{cell_idx} = 'cell';
-                end
-                fprintf('  Trace %d classified as %s\n', cell_idx, class{cell_idx});
-                cell_idx = cell_idx + 1;
-                
-            case 'n' % Not a cell
-                class{cell_idx} = 'not a cell';
-                fprintf('  Trace %d classified as %s\n', cell_idx, class{cell_idx});
+            case {'p!', 'c!', 'n'} % Classify without viewing trace
+                set_label(cell_idx, resp(1));
                 cell_idx = cell_idx + 1;
                 
             % Application options
@@ -146,3 +129,18 @@ end
 
 % Save at end!
 save_classification(class, output_name);
+
+    % Auxiliary functions
+    %------------------------------------------------------------
+    function set_label(cell_idx, label)
+        switch label
+            case 'p'
+                class{cell_idx} = 'phase-sensitive cell';
+            case 'c'
+                class{cell_idx} = 'cell';
+            case 'n'
+                class{cell_idx} = 'not a cell';
+        end
+        fprintf('  Candidate %d classified as %s\n', cell_idx, class{cell_idx});
+    end % set_label
+end % classify_cells

--- a/classification/classify_cells.m
+++ b/classification/classify_cells.m
@@ -100,6 +100,16 @@ while (cell_idx <= num_candidates)
                     cell_idx = cell_idx + 1;
                 end
 
+            case {'p!', 'c!'} % Classify without viewing trace
+                switch resp(1)
+                    case 'p'
+                        class{cell_idx} = 'phase-sensitive cell';
+                    case 'c'
+                        class{cell_idx} = 'cell';
+                end
+                fprintf('  Trace %d classified as %s\n', cell_idx, class{cell_idx});
+                cell_idx = cell_idx + 1;
+                
             case 'n' % Not a cell
                 class{cell_idx} = 'not a cell';
                 fprintf('  Trace %d classified as %s\n', cell_idx, class{cell_idx});
@@ -107,6 +117,8 @@ while (cell_idx <= num_candidates)
                 
             % Application options
             %------------------------------------------------------------
+            case ''  % Increment cell idx, loop at end
+                cell_idx = mod(cell_idx, num_candidates) + 1;
             case 'q' % Exit
                 break;
             case 's' % Save classification


### PR DESCRIPTION
Addition of a few simple commands in `classify_cells` to speed up the process:
- Can now type `p!` or `c!` to classify a cell to be phase-sensitive or cell, without viewing the trace with the movie.
- Can now press [enter] (i.e. empty string) in order to increment the candidate index.