### PR TITLE
Add debug method for setting all cells in ds to be cell

### DIFF
--- a/io/DaySummary.m
+++ b/io/DaySummary.m
@@ -12,7 +12,7 @@
 % Example usage:
 %   ds = DaySummary('c11m1d12_ti2.txt', 'rec001');
 %
-classdef DaySummary
+classdef DaySummary < handle
     properties
         cells
         trials
@@ -177,6 +177,15 @@ classdef DaySummary
         
         function is_correct = get_trial_correctness(obj)
             is_correct = cellfun(@strcmp, {obj.trials.goal}, {obj.trials.end});
+        end
+        
+        % Debug functions
+        %------------------------------------------------------------
+        function set_all_labels(obj, label)
+            % Overwrites the label of all cells in DaySummary
+            for k = 1:obj.num_cells
+                obj.cells(k).label = label;
+            end
         end
         
         % Built-in visualization functions


### PR DESCRIPTION
@inanhkn Adds method for "bulk" labeling of all cells in a `DaySummary`. Example:
```
>> m1d12 = DaySummary(sources.maze, 'sss2');
  28-Aug-2015 14:58:29: Loaded data from sss2\rec_150827-171046.mat
  28-Aug-2015 14:58:29: Loaded classification from sss2\class_150828-092948.txt
>> m1d12.set_all_labels('cell');
```
sets all cells to have the label `'cell'`.