### PR TITLE
Kimth/classify ds

### DIFF
--- a/alignment/bijective_filter.m
+++ b/alignment/bijective_filter.m
@@ -1,0 +1,37 @@
+function [match_1to2, match_2to1] = bijective_filter(match_1to2, match_2to1)
+
+for i = 1:length(match_1to2)
+    match_itoj = match_1to2{i};
+    num_matches = size(match_itoj,1);
+    if (num_matches > 1)
+        for k = 2:num_matches
+            j = match_itoj(k,1);
+            match_jtoi = match_2to1{j};
+            [~, diff_inds] = setdiff(match_jtoi(:,1), i);
+            if ~isempty(diff_inds)
+                match_2to1{j} = match_jtoi(diff_inds,:);
+            else
+                match_2to1{j} = [];
+            end
+        end
+        match_1to2{i} = match_itoj(1,:);
+    end
+end
+
+for j = 1:length(match_2to1)
+    match_jtoi = match_2to1{j};
+    num_matches = size(match_jtoi,1);
+    if (num_matches > 1)
+        for k = 2:num_matches
+            i = match_jtoi(k,1);
+            match_itoj = match_1to2{i};
+            [~, diff_inds] = setdiff(match_itoj(:,1), j);
+            if ~isempty(diff_inds)
+                match_1to2{i} = match_itoj(diff_inds,:);
+            else
+                match_1to2{i} = [];
+            end
+        end
+        match_2to1{j} = match_jtoi(1,:);
+    end
+end

--- a/alignment/run_alignment.m
+++ b/alignment/run_alignment.m
@@ -95,39 +95,5 @@ info.overlap_matrix = M;
 %------------------------------------------------------------
 if bijective_matching
     fprintf('run_alignment: Applying bijective filter...\n');
-    for i = 1:length(match_1to2)
-        match_itoj = match_1to2{i};
-        num_matches = size(match_itoj,1);
-        if (num_matches > 1)
-            for k = 2:num_matches
-                j = match_itoj(k,1);
-                match_jtoi = match_2to1{j};
-                [~, diff_inds] = setdiff(match_jtoi(:,1), i);
-                if ~isempty(diff_inds)
-                    match_2to1{j} = match_jtoi(diff_inds,:);
-                else
-                    match_2to1{j} = [];
-                end
-            end
-            match_1to2{i} = match_itoj(1,:);
-        end
-    end
-    
-    for j = 1:length(match_2to1)
-        match_jtoi = match_2to1{j};
-        num_matches = size(match_jtoi,1);
-        if (num_matches > 1)
-            for k = 2:num_matches
-                i = match_jtoi(k,1);
-                match_itoj = match_1to2{i};
-                [~, diff_inds] = setdiff(match_itoj(:,1), j);
-                if ~isempty(diff_inds)
-                    match_1to2{i} = match_itoj(diff_inds,:);
-                else
-                    match_1to2{i} = [];
-                end
-            end
-            match_2to1{j} = match_jtoi(1,:);
-        end
-    end
+    [match_1to2, match_2to1] = bijective_filter(match_1to2, match_2to1);
 end

--- a/classification/classify_cells.m
+++ b/classification/classify_cells.m
@@ -1,4 +1,4 @@
-function M = classify_cells(sources, rec_dir, varargin)
+function M = classify_cells(sources, ds, varargin)
 % Perform manual classification of candidate filter/trace pairs
 %
 % Usage:
@@ -42,7 +42,6 @@ fprintf('  %s: Movie will be displayed with fixed CLim = [%.3f %.3f]...\n',...
     datestr(now), movie_clim(1), movie_clim(2));
 
 % Load filter/trace pairs to be classified
-ds = DaySummary(sources.maze, rec_dir);
 num_candidates = ds.num_cells;
 
 trial_indices = ds.trial_indices(:, [1 end]); % [Start end]

--- a/classification/classify_cells.m
+++ b/classification/classify_cells.m
@@ -81,24 +81,17 @@ while (cell_idx <= num_candidates)
                 resp2 = lower(strtrim(resp2));
                 if (strcmp(resp, resp2)) % Confirmed
                     set_label(cell_idx, resp2);
-                    cell_idx = cell_idx + 1;
+                    go_to_next_unlabeled_cell();
                 end
 
             case {'p!', 'c!', 'n'} % Classify without viewing trace
                 set_label(cell_idx, resp(1));
-                cell_idx = cell_idx + 1;
+                go_to_next_unlabeled_cell();
                 
             % Application options
             %------------------------------------------------------------
             case ''  % Go to next unlabeled cell candidate, loop at end
-                unlabeled = strcmp(class, '');
-                unlabeled = circshift(unlabeled, -cell_idx);
-                search_offset = find(unlabeled, 1);
-                if isempty(search_offset)
-                    fprintf('  All cells have been classified!\n');
-                else
-                    cell_idx = mod(cell_idx+search_offset-1, num_candidates) + 1;
-                end
+                go_to_next_unlabeled_cell();
             case 'm' % View cell map
                 display_map();
             case 'q' % Exit
@@ -138,7 +131,7 @@ end
 save_classification(class, output_name);
 
     % Auxiliary functions
-    %------------------------------------------------------------   
+    %------------------------------------------------------------
     function display_candidate(cell_idx)
         clf;
         subplot(3,2,[1 2]);
@@ -162,6 +155,17 @@ save_classification(class, output_name);
         datacursormode off;
     end % display_map
     
+    function go_to_next_unlabeled_cell()
+        unlabeled = strcmp(class, '');
+        unlabeled = circshift(unlabeled, -cell_idx);
+        search_offset = find(unlabeled, 1);
+        if isempty(search_offset)
+            fprintf('  All cells have been classified!\n');
+        else
+            cell_idx = mod(cell_idx+search_offset-1, num_candidates) + 1;
+        end
+    end
+        
     function set_label(cell_idx, label)
         switch label
             case 'p'

--- a/classification/classify_cells.m
+++ b/classification/classify_cells.m
@@ -94,7 +94,7 @@ while (cell_idx <= num_candidates)
 end
 
 % Save at end!
-save_classification(class, output_name);
+ds.save_class(output_name);
 
     % Auxiliary functions
     %------------------------------------------------------------
@@ -122,7 +122,8 @@ save_classification(class, output_name);
     end % display_map
     
     function go_to_next_unlabeled_cell()
-        unlabeled = strcmp(class, '');
+        labels = ds.get_class;
+        unlabeled = strcmp(labels, '');
         unlabeled = circshift(unlabeled, -cell_idx);
         search_offset = find(unlabeled, 1);
         if isempty(search_offset)
@@ -135,13 +136,13 @@ save_classification(class, output_name);
     function set_label(cell_idx, label)
         switch label
             case 'p'
-                class{cell_idx} = 'phase-sensitive cell';
+                full_label = 'phase-sensitive cell';
             case 'c'
-                class{cell_idx} = 'cell';
+                full_label = 'cell';
             case 'n'
-                class{cell_idx} = 'not a cell';
+                full_label = 'not a cell';
         end
-        ds.cells(cell_idx).label = class{cell_idx}; % Needed for display_map
-        fprintf('  Candidate %d classified as %s\n', cell_idx, class{cell_idx});
+        ds.cells(cell_idx).label = full_label;
+        fprintf('  Candidate %d classified as %s\n', cell_idx, full_label);
     end % set_label
 end % classify_cells

--- a/classification/load_classification.m
+++ b/classification/load_classification.m
@@ -1,7 +1,0 @@
-function class = load_classification(source)
-
-fid = fopen(source, 'r');
-class = textscan(fid, '%d %s', 'Delimiter', ',');
-fclose(fid);
-
-class = class{2};

--- a/classification/save_classification.m
+++ b/classification/save_classification.m
@@ -1,9 +1,0 @@
-function save_classification(class, outfile)
-
-num_traces = length(class);
-
-fid = fopen(outfile, 'w');
-for trace_idx = 1:num_traces
-    fprintf(fid, '%d, %s\n', trace_idx, class{trace_idx});
-end
-fclose(fid);

--- a/ds/@DaySummary/DaySummary.m
+++ b/ds/@DaySummary/DaySummary.m
@@ -40,6 +40,12 @@ classdef DaySummary < handle
                 end
             end
             
+            % Parse trial data
+            %------------------------------------------------------------
+            [trial_indices, loc_info, trial_durations] =...
+                parse_plusmaze(plusmaze_txt); %#ok<*PROP>
+            fprintf('  %s: Loaded trial metadata from %s\n', datestr(now), plusmaze_txt);
+            
             % Load data
             %------------------------------------------------------------
             data_source = get_most_recent_file(rec_dir, 'rec_*.mat');
@@ -47,14 +53,8 @@ classdef DaySummary < handle
             obj.num_cells = data.info.num_pairs;
             fprintf('  %s: Loaded filters/traces from %s\n', datestr(now), data_source);
             
-            % Parse trial data
-            %   TODO: Bring in centroids corresponding to mouse position
-            %------------------------------------------------------------
-            [trial_indices, loc_info, trial_durations] =...
-                parse_plusmaze(plusmaze_txt); %#ok<*PROP>
-            
             % Check that the length of traces is consistent with the table
-            % of trial indices
+            % of trial indices.
             assert(size(data.traces,1) == trial_indices(end,end),...
                 'Error: Length of traces does not match trial index table!');
             
@@ -90,18 +90,8 @@ classdef DaySummary < handle
             
             % Parse cell data
             %------------------------------------------------------------
-            class_source = get_most_recent_file(rec_dir, 'class_*.txt');
-            if ~isempty(class_source)
-                class = obj.load_classification(class_source);
-                fprintf('  %s: Loaded classification from %s\n', datestr(now), class_source);
-                assert(length(class)==obj.num_cells,...
-                       sprintf('Number of labels in %s is not consistent with %s!',...
-                               class_source, data_source));
-            else % No classification file
-                fprintf('  %s: No classification file in %s!\n', datestr(now), rec_dir);
-                class = cell(obj.num_cells,1); % Empty
-            end
-
+            class = cell(obj.num_cells,1);
+            
             images = squeeze(num2cell(data.filters, [1 2])); % images{k} is the 2D image of cell k
             [height, width] = size(images{1});
             boundaries = cell(size(images));
@@ -119,7 +109,16 @@ classdef DaySummary < handle
                 'mask', masks,...
                 'label', class);
             
-            % Precompute cell map image, to avoid doing it each time 
+            % Load classification
+            %------------------------------------------------------------
+            class_source = get_most_recent_file(rec_dir, 'class_*.txt');
+            if ~isempty(class_source)
+                obj.load_class(class_source);
+                fprintf('  %s: Loaded classification from %s\n', datestr(now), class_source);
+            end
+            
+            % Precompute cell map image, to avoid doing it each time
+            %------------------------------------------------------------
             [height, width] = size(obj.cells(1).im);
             ref_image = zeros(height, width);
             for k = 1:obj.num_cells
@@ -142,6 +141,33 @@ classdef DaySummary < handle
                 turn = 'right';
             end
         end
+        
+        function filtered_trials = filter_trials(obj, varargin)
+            filtered_trials = ones(1, obj.num_trials);
+            for k = 1:length(varargin)
+                vararg = varargin{k};
+                if ischar(vararg)
+                    switch lower(vararg)
+                        case 'incorrect'
+                            filtered_trials = filtered_trials &...
+                                (~strcmp({obj.trials.goal}, {obj.trials.end}));
+                        case 'correct'
+                            filtered_trials = filtered_trials &...
+                                strcmp({obj.trials.goal}, {obj.trials.end});
+                        case 'start'
+                            filtered_trials = filtered_trials &...
+                                strcmp({obj.trials.start}, varargin{k+1});
+                        case 'end'
+                            filtered_trials = filtered_trials &...
+                                strcmp({obj.trials.end}, varargin{k+1});
+                        case 'turn'
+                            filtered_trials = filtered_trials &...
+                                strcmp({obj.trials.turn}, varargin{k+1});
+                    end
+                end
+            end
+            filtered_trials = filtered_trials';
+        end   
         
         % Accessors
         %------------------------------------------------------------
@@ -202,256 +228,6 @@ classdef DaySummary < handle
             % Overwrites the label of all cells in DaySummary
             for k = 1:obj.num_cells
                 obj.cells(k).label = label;
-            end
-        end
-        
-        % Built-in visualization functions
-        % Note: Do NOT make use of subplots in the built-in plot methods
-        %------------------------------------------------------------
-        function plot_cell_map(obj, color_grouping, varargin)
-            % Optional argument allows for specification of color used for
-            % the cell in the cell map. The color specification is defined
-            % as follows:
-            %   color_grouping = {[1, 2, 3, 4], 'w';
-            %                     [5, 6], 'r';
-            %                     [10], 'g'}
-            % means that cells [1, 2, 3, 4] will be displayed in white,
-            % cells [5, 6] in red, and [10] in green.
-            
-            enable_class_colors = 0;
-            for k = 1:length(varargin)
-                vararg = varargin{k};
-                if ischar(vararg)
-                    switch lower(vararg)
-                        % By default, if 'color_grouping' is provided, the
-                        % default boundary coloring by classification is
-                        % disabled. The following toggle enables the
-                        % class colors, which is then overridden by the
-                        % specified 'color_grouping'
-                        case 'enable_class_colors'
-                            enable_class_colors = 1;
-                    end
-                end
-            end
-            
-            cell_colors = cell(obj.num_cells, 1);
-                        
-            % By default, color the cells based on classification
-            if ~exist('color_grouping', 'var') || enable_class_colors
-                for k = 1:obj.num_cells
-                    % Note: Unlabeled cells remain white!
-                    if isempty(obj.cells(k).label)
-                        cell_colors{k} = 'w';
-                    else
-                        if obj.is_cell(k)
-                            cell_colors{k} = 'g';
-                        else
-                            cell_colors{k} = 'r';
-                        end
-                    end
-                end
-            end
-            
-            % Color grouping provided, unpack into cell_linespec
-            if exist('color_grouping', 'var')
-                for group = 1:size(color_grouping, 1)
-                    for cell_idx = color_grouping{group,1}
-                        cell_colors{cell_idx} = color_grouping{group,2};
-                    end
-                end
-            end
-            
-            % Display the cell map
-            imagesc(obj.cell_map_ref_img, 'HitTest', 'off');
-            colormap gray;
-            axis equal tight;
-            
-            hold on;
-            for k = 1:obj.num_cells
-                if ~isempty(cell_colors{k})
-                    boundary = obj.cells(k).boundary;
-                    
-                    if strcmp(cell_colors{k}, 'w')
-                        linewidth = 0.25;
-                        alpha = 0.1; % Lower is more transparent
-                    else
-                        linewidth = 1.0;
-                        alpha = 0.3;
-                    end
-                    
-                    % Note: We are embedding the cell index in the
-                    %   z-dimension of the graphics object (hack!)
-                    fill3(boundary(:,1), boundary(:,2),...
-                         k*ones(size(boundary,1),1),...
-                         cell_colors{k},...
-                         'EdgeColor', cell_colors{k},...
-                         'LineWidth', linewidth,...
-                         'FaceAlpha', alpha);
-                end
-            end
-            hold off;
-            
-            dcm = datacursormode(gcf);
-            set(dcm, 'DisplayStyle', 'datatip');
-            set(dcm, 'UpdateFcn', @cellmap_tooltip);
-            datacursormode on;
-        end
-        
-        function plot_trace(obj, cell_idx)
-            % Plot the trace of a single cell, color-coded by trial
-            trace_min = Inf;
-            trace_max = -Inf;
-            
-            colors = 'kbr';
-            for k = 1:obj.num_trials
-                [trace, inds] = obj.get_trace(cell_idx, k);
-                
-                trial_trace_min = min(trace);
-                trial_trace_max = max(trace);
-                if (trial_trace_min < trace_min)
-                    trace_min = trial_trace_min;
-                end
-                if (trial_trace_max > trace_max)
-                    trace_max = trial_trace_max;
-                end
-                
-                plot(inds, trace,...
-                     colors(mod(k,length(colors))+1));
-                hold on;
-            end
-            hold off;
-            xlim([1 inds(end)]); % Using the last 'inds' from loop!
-            trace_delta = trace_max - trace_min;
-            ylim([trace_min trace_max] + 0.1*trace_delta*[-1 1]);
-            xlabel('Frame index');
-            ylabel('Signal [a.u.]');
-        end
-        
-        function filtered_trials = filter_trials(obj, varargin)
-            filtered_trials = ones(1, obj.num_trials);
-            for k = 1:length(varargin)
-                vararg = varargin{k};
-                if ischar(vararg)
-                    switch lower(vararg)
-                        case 'incorrect'
-                            filtered_trials = filtered_trials &...
-                                (~strcmp({obj.trials.goal}, {obj.trials.end}));
-                        case 'correct'
-                            filtered_trials = filtered_trials &...
-                                strcmp({obj.trials.goal}, {obj.trials.end});
-                        case 'start'
-                            filtered_trials = filtered_trials &...
-                                strcmp({obj.trials.start}, varargin{k+1});
-                        case 'end'
-                            filtered_trials = filtered_trials &...
-                                strcmp({obj.trials.end}, varargin{k+1});
-                        case 'turn'
-                            filtered_trials = filtered_trials &...
-                                strcmp({obj.trials.turn}, varargin{k+1});
-                    end
-                end
-            end
-            filtered_trials = filtered_trials';
-        end
-        
-        function plot_superposed_trials(obj, cell_idx, varargin)
-            % Optional arguments allow for filtering of trials, e.g.
-            %   "plot_superposed_trials(cell_idx, 'start', 'east')"
-            display_trial = ones(obj.num_trials, 1);
-            if ~isempty(varargin)
-                display_trial = obj.filter_trials(varargin{:});
-            end
-            
-            trace_min = Inf;
-            trace_max = -Inf;
-            
-            colors = 'kbr';
-            for k = 1:obj.num_trials
-                if display_trial(k)
-                    trial_trace = obj.get_trace(cell_idx, k);
-
-                    trial_trace_min = min(trial_trace);
-                    trial_trace_max = max(trial_trace);
-                    if (trial_trace_min < trace_min)
-                        trace_min = trial_trace_min;
-                    end
-                    if (trial_trace_max > trace_max)
-                        trace_max = trial_trace_max;
-                    end
-
-                    plot(linspace(0, 1, length(trial_trace)),...
-                         trial_trace,...
-                         colors(mod(k,length(colors))+1));
-                    hold on;
-                end
-            end
-            hold off;
-            grid on;
-            xlim([0 1]);
-            trace_delta = trace_max - trace_min;
-            ylim([trace_min trace_max] + 0.1*trace_delta*[-1 1]);
-            xlabel('Trial phase [a.u.]');
-            ylabel('Trace [a.u.]');
-        end
-        
-        function raster = plot_cell_raster(obj, cell_idx, varargin)
-            % Optional argument 'draw_correct' will place a box at the end
-            % of each trial indicating correct (green) or incorrect (red)
-            %
-            % Additional optional arguments allow for filtering of trials,
-            % e.g. "plot_cell_raster(cell_idx, 'start', 'east')"
-            
-            display_trial = ones(obj.num_trials, 1);
-            draw_correct = 0;
-            if ~isempty(varargin)
-                for k = 1:length(varargin)
-                    vararg = varargin{k};
-                    if ischar(vararg)
-                        switch lower(vararg)
-                            case 'draw_correct'
-                                draw_correct = 1;
-                        end
-                    end
-                end
-                % Trial filtering arguments
-                display_trial = obj.filter_trials(varargin{:});
-            end
-                        
-            resample_grid = linspace(0, 1, 1000);
-            num_filtered_trials = sum(display_trial);
-            raster = zeros(num_filtered_trials, length(resample_grid));
-            correctness = zeros(num_filtered_trials);
-            counter = 0;
-            for k = 1:obj.num_trials
-                if display_trial(k)
-                    counter = counter+1;
-                    line = obj.get_trace(cell_idx, k);
-                    raster(counter,:) = interp1(linspace(0,1,length(line)),...
-                                      line,...
-                                      resample_grid,...
-                                      'pchip');
-                    correctness(counter) = obj.trials(k).correct;
-                end
-            end
-            
-            imagesc(resample_grid, 1:size(raster,1), raster);
-            colormap jet;
-            xlabel('Trial phase [a.u.]');
-            xlim([0 1]);
-            ylabel('Trial index');
-            
-            if (draw_correct)
-                corr_width = 0.025;
-                for k = 1:num_filtered_trials
-                    if correctness(k)
-                        corr_color = 'g';
-                    else
-                        corr_color = 'r';
-                    end
-                    rectangle('Position', [1 k-0.5 corr_width 1],...
-                              'FaceColor', corr_color);
-                end
-                xlim([0 1+corr_width]);
             end
         end
     end

--- a/ds/@DaySummary/DaySummary.m
+++ b/ds/@DaySummary/DaySummary.m
@@ -51,7 +51,7 @@ classdef DaySummary < handle
             data_source = get_most_recent_file(rec_dir, 'rec_*.mat');
             data = load(data_source);
             obj.num_cells = data.info.num_pairs;
-            fprintf('  %s: Loaded filters/traces from %s\n', datestr(now), data_source);
+            fprintf('  %s: Loaded filters and traces from %s\n', datestr(now), data_source);
             
             % Check that the length of traces is consistent with the table
             % of trial indices.

--- a/ds/@DaySummary/DaySummary.m
+++ b/ds/@DaySummary/DaySummary.m
@@ -92,7 +92,7 @@ classdef DaySummary < handle
             %------------------------------------------------------------
             class_source = get_most_recent_file(rec_dir, 'class_*.txt');
             if ~isempty(class_source)
-                class = load_classification(class_source);
+                class = obj.load_classification(class_source);
                 fprintf('  %s: Loaded classification from %s\n', datestr(now), class_source);
                 assert(length(class)==obj.num_cells,...
                        sprintf('Number of labels in %s is not consistent with %s!',...
@@ -173,10 +173,6 @@ classdef DaySummary < handle
             end
         end
         
-        function class = get_class(obj)
-            class = {obj.cells.label}'; % Column cell
-        end
-        
         function is_cell = is_cell(obj, cell_indices)
             % When 'cell_indices' is omitted, then return the label of all
             % cells
@@ -196,8 +192,12 @@ classdef DaySummary < handle
             is_correct = cellfun(@strcmp, {obj.trials.goal}, {obj.trials.end});
         end
         
-        % Debug functions
+        % Classification
         %------------------------------------------------------------
+        function class = get_class(obj)
+            class = {obj.cells.label}'; % Column cell
+        end
+        
         function set_all_labels(obj, label)
             % Overwrites the label of all cells in DaySummary
             for k = 1:obj.num_cells

--- a/ds/@DaySummary/load_class.m
+++ b/ds/@DaySummary/load_class.m
@@ -5,6 +5,11 @@ class = textscan(fid, '%d %s', 'Delimiter', ',');
 fclose(fid);
 
 class = class{2};
+num_class = length(class);
+assert(num_class == obj.num_cells,...
+       sprintf('Number of labels in %s (%d) does not match number of cells (%d) in DaySummary!',...
+               source, num_class, obj.num_cells));
+
 for k = 1:obj.num_cells
     obj.cells(k).label = class{k};
 end

--- a/ds/@DaySummary/load_class.m
+++ b/ds/@DaySummary/load_class.m
@@ -1,4 +1,4 @@
-function load_classification(obj, source)
+function load_class(obj, source)
 
 fid = fopen(source, 'r');
 class = textscan(fid, '%d %s', 'Delimiter', ',');

--- a/ds/@DaySummary/load_classification.m
+++ b/ds/@DaySummary/load_classification.m
@@ -1,0 +1,10 @@
+function load_classification(obj, source)
+
+fid = fopen(source, 'r');
+class = textscan(fid, '%d %s', 'Delimiter', ',');
+fclose(fid);
+
+class = class{2};
+for k = 1:obj.num_cells
+    obj.cells(k).label = class{k};
+end

--- a/ds/@DaySummary/plot_cell_map.m
+++ b/ds/@DaySummary/plot_cell_map.m
@@ -1,0 +1,88 @@
+function plot_cell_map(obj, color_grouping, varargin)
+    % Optional argument allows for specification of color used for
+    % the cell in the cell map. The color specification is defined
+    % as follows:
+    %   color_grouping = {[1, 2, 3, 4], 'w';
+    %                     [5, 6], 'r';
+    %                     [10], 'g'}
+    % means that cells [1, 2, 3, 4] will be displayed in white,
+    % cells [5, 6] in red, and [10] in green.
+
+    enable_class_colors = 0;
+    for k = 1:length(varargin)
+        vararg = varargin{k};
+        if ischar(vararg)
+            switch lower(vararg)
+                % By default, if 'color_grouping' is provided, the
+                % default boundary coloring by classification is
+                % disabled. The following toggle enables the
+                % class colors, which is then overridden by the
+                % specified 'color_grouping'
+                case 'enable_class_colors'
+                    enable_class_colors = 1;
+            end
+        end
+    end
+
+    cell_colors = cell(obj.num_cells, 1);
+
+    % By default, color the cells based on classification
+    if ~exist('color_grouping', 'var') || enable_class_colors
+        for k = 1:obj.num_cells
+            % Note: Unlabeled cells remain white!
+            if isempty(obj.cells(k).label)
+                cell_colors{k} = 'w';
+            else
+                if obj.is_cell(k)
+                    cell_colors{k} = 'g';
+                else
+                    cell_colors{k} = 'r';
+                end
+            end
+        end
+    end
+
+    % Color grouping provided, unpack into cell_linespec
+    if exist('color_grouping', 'var')
+        for group = 1:size(color_grouping, 1)
+            for cell_idx = color_grouping{group,1}
+                cell_colors{cell_idx} = color_grouping{group,2};
+            end
+        end
+    end
+
+    % Display the cell map
+    imagesc(obj.cell_map_ref_img, 'HitTest', 'off');
+    colormap gray;
+    axis equal tight;
+
+    hold on;
+    for k = 1:obj.num_cells
+        if ~isempty(cell_colors{k})
+            boundary = obj.cells(k).boundary;
+
+            if strcmp(cell_colors{k}, 'w')
+                linewidth = 0.25;
+                alpha = 0.1; % Lower is more transparent
+            else
+                linewidth = 1.0;
+                alpha = 0.3;
+            end
+
+            % Note: We are embedding the cell index in the
+            %   z-dimension of the graphics object (hack!)
+            fill3(boundary(:,1), boundary(:,2),...
+                 k*ones(size(boundary,1),1),...
+                 cell_colors{k},...
+                 'EdgeColor', cell_colors{k},...
+                 'LineWidth', linewidth,...
+                 'FaceAlpha', alpha);
+        end
+    end
+    hold off;
+
+    dcm = datacursormode(gcf);
+    set(dcm, 'DisplayStyle', 'datatip');
+    set(dcm, 'UpdateFcn', @cellmap_tooltip);
+    datacursormode on;
+end

--- a/ds/@DaySummary/plot_cell_raster.m
+++ b/ds/@DaySummary/plot_cell_raster.m
@@ -1,0 +1,60 @@
+function raster = plot_cell_raster(obj, cell_idx, varargin)
+    % Optional argument 'draw_correct' will place a box at the end
+    % of each trial indicating correct (green) or incorrect (red)
+    %
+    % Additional optional arguments allow for filtering of trials,
+    % e.g. "plot_cell_raster(cell_idx, 'start', 'east')"
+
+    display_trial = ones(obj.num_trials, 1);
+    draw_correct = 0;
+    if ~isempty(varargin)
+        for k = 1:length(varargin)
+            vararg = varargin{k};
+            if ischar(vararg)
+                switch lower(vararg)
+                    case 'draw_correct'
+                        draw_correct = 1;
+                end
+            end
+        end
+        % Trial filtering arguments
+        display_trial = obj.filter_trials(varargin{:});
+    end
+
+    resample_grid = linspace(0, 1, 1000);
+    num_filtered_trials = sum(display_trial);
+    raster = zeros(num_filtered_trials, length(resample_grid));
+    correctness = zeros(num_filtered_trials);
+    counter = 0;
+    for k = 1:obj.num_trials
+        if display_trial(k)
+            counter = counter+1;
+            line = obj.get_trace(cell_idx, k);
+            raster(counter,:) = interp1(linspace(0,1,length(line)),...
+                              line,...
+                              resample_grid,...
+                              'pchip');
+            correctness(counter) = obj.trials(k).correct;
+        end
+    end
+
+    imagesc(resample_grid, 1:size(raster,1), raster);
+    colormap jet;
+    xlabel('Trial phase [a.u.]');
+    xlim([0 1]);
+    ylabel('Trial index');
+
+    if (draw_correct)
+        corr_width = 0.025;
+        for k = 1:num_filtered_trials
+            if correctness(k)
+                corr_color = 'g';
+            else
+                corr_color = 'r';
+            end
+            rectangle('Position', [1 k-0.5 corr_width 1],...
+                      'FaceColor', corr_color);
+        end
+        xlim([0 1+corr_width]);
+    end
+end

--- a/ds/@DaySummary/plot_superposed_trials.m
+++ b/ds/@DaySummary/plot_superposed_trials.m
@@ -1,0 +1,39 @@
+function plot_superposed_trials(obj, cell_idx, varargin)
+    % Optional arguments allow for filtering of trials, e.g.
+    %   "plot_superposed_trials(cell_idx, 'start', 'east')"
+    display_trial = ones(obj.num_trials, 1);
+    if ~isempty(varargin)
+        display_trial = obj.filter_trials(varargin{:});
+    end
+
+    trace_min = Inf;
+    trace_max = -Inf;
+
+    colors = 'kbr';
+    for k = 1:obj.num_trials
+        if display_trial(k)
+            trial_trace = obj.get_trace(cell_idx, k);
+
+            trial_trace_min = min(trial_trace);
+            trial_trace_max = max(trial_trace);
+            if (trial_trace_min < trace_min)
+                trace_min = trial_trace_min;
+            end
+            if (trial_trace_max > trace_max)
+                trace_max = trial_trace_max;
+            end
+
+            plot(linspace(0, 1, length(trial_trace)),...
+                 trial_trace,...
+                 colors(mod(k,length(colors))+1));
+            hold on;
+        end
+    end
+    hold off;
+    grid on;
+    xlim([0 1]);
+    trace_delta = trace_max - trace_min;
+    ylim([trace_min trace_max] + 0.1*trace_delta*[-1 1]);
+    xlabel('Trial phase [a.u.]');
+    ylabel('Trace [a.u.]');
+end

--- a/ds/@DaySummary/plot_trace.m
+++ b/ds/@DaySummary/plot_trace.m
@@ -1,0 +1,29 @@
+function plot_trace(obj, cell_idx)
+    % Plot the trace of a single cell, color-coded by trial
+    trace_min = Inf;
+    trace_max = -Inf;
+
+    colors = 'kbr';
+    for k = 1:obj.num_trials
+        [trace, inds] = obj.get_trace(cell_idx, k);
+
+        trial_trace_min = min(trace);
+        trial_trace_max = max(trace);
+        if (trial_trace_min < trace_min)
+            trace_min = trial_trace_min;
+        end
+        if (trial_trace_max > trace_max)
+            trace_max = trial_trace_max;
+        end
+
+        plot(inds, trace,...
+             colors(mod(k,length(colors))+1));
+        hold on;
+    end
+    hold off;
+    xlim([1 inds(end)]); % Using the last 'inds' from loop!
+    trace_delta = trace_max - trace_min;
+    ylim([trace_min trace_max] + 0.1*trace_delta*[-1 1]);
+    xlabel('Frame index');
+    ylabel('Signal [a.u.]');
+end

--- a/ds/@DaySummary/save_class.m
+++ b/ds/@DaySummary/save_class.m
@@ -1,4 +1,4 @@
-function save_classification(obj, outfile)
+function save_class(obj, outfile)
 
 num_candidates = obj.num_cells;
 

--- a/ds/@DaySummary/save_classification.m
+++ b/ds/@DaySummary/save_classification.m
@@ -1,0 +1,9 @@
+function save_classification(obj, outfile)
+
+num_candidates = obj.num_cells;
+
+fid = fopen(outfile, 'w');
+for k = 1:num_candidates
+    fprintf(fid, '%d, %s\n', k, obj.cells(k).label);
+end
+fclose(fid);


### PR DESCRIPTION
Refactoring of `DaySummary` and `classify_cells`. Most changes are behind the scenes. No additions to Matlab path are required.

The main conceptual change is that `classify_cells` is thought of as an operation on an existing `DaySummary`. The proper way to invoke `classify_cells` is now as follows:
```
>> sources = data_sources

sources = 

         maze: '_data/c11m1d12_ti2.txt'
    miniscope: '_data/c11m1d12_cr_gfix_mc_cr_norm_dff_ti2.hdf5'
          pca: '_data/pca_n700.mat'
          fps: 10

>> M = load_movie(sources.miniscope);
>> m1d12_cm01 = DaySummary(sources.maze, 'cm01');
  31-Aug-2015 12:15:14: Loaded trial metadata from _data/c11m1d12_ti2.txt
  31-Aug-2015 12:15:18: Loaded filters/traces from cm01\rec_150819-203737.mat
>> classify_cells(m1d12_cm01, M);
```
Note that `classify_cells` now expects a movie matrix directly. Note also that the use of the `sources` structure is less motivated than before. (I still use it for convenience.)

The conceptual change where `classify_cells` "operates" on a DaySummary was motivated by the workflow where one can copy labels from one DaySummary to another (with sufficient spatial overlap), and then `classify_cells` is used to label the unmatched cells.

Within `classify_cells`, there is one new behavior which is that, when you press "[Enter]" in the prompt, the routine will jump to the next unlabeled cell (in index).