### PR TITLE
N or M button will show neighbors

### DIFF
--- a/classification/support/view_cell_interactively.m
+++ b/classification/support/view_cell_interactively.m
@@ -171,7 +171,7 @@ while (1)
                 end
                 set(gca, 'CLim', movie_clim);
                 
-            case 'n' % Show "neighboring" cells
+            case {'n', 'm'} % Show "neighboring" cells
                 state.show_other_cells = ~state.show_other_cells;
                 show_other_cells(state.show_other_cells);
 


### PR DESCRIPTION
When viewing traces alongside the movie, `n` or `m` will show the neighboring cells. The `m` is because of the new "map" mnemonic.