### PR TITLE
Kimth/refactor alignment

### DIFF
--- a/alignment/compute_affine_transform.m
+++ b/alignment/compute_affine_transform.m
@@ -49,11 +49,12 @@ while (~all(sel_ics_idx == num_ics_for_alignment))
     click_xy = round(ginput(1)); % Get user click
     if (gca == ax1) % Axis 1 was clicked
         source_idx = 1;
+        ic_idx = ds1.get_cell_by_xy(click_xy);
     elseif (gca == ax2)
         source_idx = 2;
+        ic_idx = ds2.get_cell_by_xy(click_xy);
     end
     
-    ic_idx = get_selected_ic_idx(bounds{source_idx}, click_xy);
     if ~isempty(ic_idx) % Hit
         sel_idx = sel_ics_idx(source_idx) + 1;
         if (sel_idx <= num_ics_for_alignment)
@@ -170,19 +171,5 @@ function plot_boundaries(boundaries, cl, linespec, linewidth, sel_ics, tform)
             end
         end
         hold on;
-    end
-end
-
-function selected_ic_idx = get_selected_ic_idx(boundaries, click_xy)
-    % Return the first IC index whose filter boundary encloses the
-    %   XY position provided in `click_xy`
-    num_ics = length(boundaries);
-    selected_ic_idx = []; % If no hit, then return empty
-    for ic_idx = 1:num_ics
-        bound = boundaries{ic_idx};
-        if inpolygon(click_xy(1), click_xy(2), bound(:,1), bound(:,2))
-            selected_ic_idx = ic_idx;
-            break;
-        end
     end
 end

--- a/ds/@DaySummary/DaySummary.m
+++ b/ds/@DaySummary/DaySummary.m
@@ -218,6 +218,20 @@ classdef DaySummary < handle
             is_correct = cellfun(@strcmp, {obj.trials.goal}, {obj.trials.end});
         end
         
+        function selected_idx = get_cell_by_xy(obj, xy)
+            % Returns the first cell index whose filter boundary encloses
+            % the XY position provided in 'xy'
+            
+            selected_idx = []; % If no hit, then return empty
+            for k = 1:obj.num_cells
+                boundary = obj.cells(k).boundary;
+                if inpolygon(xy(1), xy(2), boundary(:,1), boundary(:,2))
+                    selected_idx = k;
+                    break;
+                end
+            end
+        end
+        
         % Classification
         %------------------------------------------------------------
         function class = get_class(obj)

--- a/ds/@DaySummary/plot_cell_boundaries.m
+++ b/ds/@DaySummary/plot_cell_boundaries.m
@@ -1,0 +1,18 @@
+function plot_cell_boundaries(obj)
+    % Display the cell map
+    imagesc(obj.cell_map_ref_img);
+    colormap gray;
+    axis equal tight;
+
+    hold on;
+    for k = 1:obj.num_cells
+        boundary = obj.cells(k).boundary;
+        if obj.is_cell(k)
+            color = 'g';
+        else
+            color = 'r';
+        end
+        plot(boundary(:,1), boundary(:,2), color);
+    end
+    hold off;
+end


### PR DESCRIPTION
Slight refactor of `run_alignment.m`, which was written before the use of `DaySummary`. (It was quickly retrofitted to make use of `DaySummary` inputs.)

No changes to the overt behavior of `run_alignment.m`. Alignment script can be used as before. The boot-up process for `run_alignment.m` should be a bit faster now, since it makes use of pre-computed variables within `DaySummary` (i.e. boundaries and masks, which already exists within `DaySummary`).

In general, I am absorbing various functionalities (e.g. the ability to click on a cell by mouse click) into `DaySummary`. This allows us to use the functionalities in other scripts -- my eye is set on merging filters from multiple `DaySummary`s.

