### PR TITLE
Kimth/align without transform

### DIFF
--- a/alignment/run_alignment.m
+++ b/alignment/run_alignment.m
@@ -21,9 +21,12 @@ function [match_1to2, match_2to1] = run_alignment(ds1, ds2, varargin)
 %   [m1to2, m2to1] = run_alignment('c9m7d07_ica001', 'c9m7d08_ica001');
 %
 
+% Default alignment options
+%------------------------------------------------------------
 use_transform = 1;
 fast_matching = 0;
-bijective_matching = 0;
+bijective_matching = 1;
+
 for k = 1:length(varargin)
     if ischar(varargin{k})
         switch varargin{k}
@@ -38,8 +41,8 @@ for k = 1:length(varargin)
                 assert(all(size(ds1.cells(1).mask)==size(ds2.cells(1).mask)),...
                     'notrans option requires cell image dimensions to be identical!');
                 use_transform = 0;
-            case {'one-to-one', 'bijective'}
-                bijective_matching = 1;
+            case 'keepall' % Keep all matches
+                bijective_matching = 0;
         end
     end
 end

--- a/alignment/run_alignment.m
+++ b/alignment/run_alignment.m
@@ -1,4 +1,4 @@
-function [match_1to2, match_2to1, info] = run_alignment(ds1, ds2, varargin)
+function [match_1to2, match_2to1] = run_alignment(ds1, ds2, varargin)
 % Align two sets of cell filters.
 %
 % Inputs:
@@ -21,10 +21,23 @@ function [match_1to2, match_2to1, info] = run_alignment(ds1, ds2, varargin)
 %   [m1to2, m2to1] = run_alignment('c9m7d07_ica001', 'c9m7d08_ica001');
 %
 
+use_transform = 1;
+fast_matching = 0;
 bijective_matching = 0;
 for k = 1:length(varargin)
     if ischar(varargin{k})
         switch varargin{k}
+            case 'fast'
+                % Use fast -- nonexhaustive -- matching of masks. See
+                % 'match_masks' for further details
+                fast_matching = 1;
+            case 'notrans'
+                % No affine transform needed (e.g. for matching multiple
+                % extraction runs on the same movie). Requires the image
+                % dimensions to be identical!
+                assert(all(size(ds1.cells(1).mask)==size(ds2.cells(1).mask)),...
+                    'notrans option requires cell image dimensions to be identical!');
+                use_transform = 0;
             case {'one-to-one', 'bijective'}
                 bijective_matching = 1;
         end
@@ -33,18 +46,27 @@ end
 
 % Control point-based registration of two sets of ICs
 %------------------------------------------------------------
-fprintf('run_alignment: Beginning alignment...\n');    
-[affine_info, masks1, masks2_tform] = compute_affine_transform(ds1, ds2);
-
+if use_transform
+    fprintf('run_alignment: Beginning alignment...\n');
+    [~, masks1, masks2] = compute_affine_transform(ds1, ds2);
+else
+    masks1 = {ds1.cells.mask};
+    masks2 = {ds2.cells.mask};
+    
+    figure;
+    ds1.plot_cell_boundaries('nobackground', 'cells', 'linespec', 'b', 'linewidth', 2);
+    hold on;
+    ds2.plot_cell_boundaries('nobackground', 'cells', 'linespec', 'r', 'linewidth', 1);
+    title('Dataset1 (blue) vs. Dataset2 (red)');
+end
 input('run_alignment: Press any key to continue with mask matching >> ');
-[match_1to2, match_2to1, M] = match_masks(masks1, masks2_tform);
 
-% Set up auxiliary output
-%------------------------------------------------------------
-info.affine = affine_info;
-info.masks1 = masks1;
-info.masks2 = masks2_tform;
-info.overlap_matrix = M;
+if fast_matching
+    [match_1to2, match_2to1] = match_masks(masks1, masks2, 'fast');
+else
+    [match_1to2, match_2to1] = match_masks(masks1, masks2);
+end
+
 
 % Optional bijective filtering
 %------------------------------------------------------------

--- a/ds/@DaySummary/plot_cell_boundaries.m
+++ b/ds/@DaySummary/plot_cell_boundaries.m
@@ -1,18 +1,56 @@
-function plot_cell_boundaries(obj)
-    % Display the cell map
-    imagesc(obj.cell_map_ref_img);
-    colormap gray;
-    axis equal tight;
+function plot_cell_boundaries(obj, varargin)
+    % Default display options
+    show_cell_map_background = 1;
+    cells_only = 0;
+    linespec = [];
+    linewidth = 1;
+    for k = 1:length(varargin)
+        if ischar(varargin{k})
+            switch lower(varargin{k})
+                case 'nobackground'
+                    show_cell_map_background = 0;
+                case {'cells', 'cellsonly'}
+                    cells_only = 1;
+                case 'linespec'
+                    % Overrides default coloring by cell label
+                    linespec = varargin{k+1};
+                case 'linewidth'
+                    linewidth = varargin{k+1};
+            end
+        end
+    end
 
+    % Display the cell map
+    if show_cell_map_background
+        imagesc(obj.cell_map_ref_img);
+        colormap gray;
+    else
+        [h, w] = size(obj.cell_map_ref_img);
+        plot([1 w w 1], [h h 1 1], 'k');
+        set(gca, 'YDir', 'Reverse');
+    end
     hold on;
+    axis equal tight;
+            
     for k = 1:obj.num_cells
         boundary = obj.cells(k).boundary;
-        if obj.is_cell(k)
-            color = 'g';
+        
+        % By default, boundary colors are defined by cell label, but can be
+        % overriden by 'linespec' varargin
+        if isempty(linespec)
+            if obj.is_cell(k)
+                ls = 'g';
+            else
+                ls = 'r';
+            end
         else
-            color = 'r';
+            ls = linespec;
         end
-        plot(boundary(:,1), boundary(:,2), color);
+        
+        if obj.is_cell(k) || ~cells_only
+            plot(boundary(:,1), boundary(:,2), ls, 'linewidth', linewidth);
+        end
+        
     end
     hold off;
 end


### PR DESCRIPTION
These days, I am running a lot of alignment jobs between different extractions on the same movie. For these alignments, the affine transformation step is unnecessary; all we need is a direct overlay.

This PR modifies `run_alignment.m` to explicitly give an option to match without the affine transformation step, to be invoked using the `notrans` toggle as follows:
```
>> m1d12_sss2 = DaySummary(sources.maze, 'sss2');
  31-Aug-2015 22:10:51: Loaded trial metadata from _data/c11m1d12_ti2.txt
  31-Aug-2015 22:10:54: Loaded filters and traces from sss2\rec_150827-171046.mat
  31-Aug-2015 22:11:04: Loaded classification from sss2\class_150828-092948.txt
>> m1d12_sss3 = DaySummary(sources.maze, 'sss3');
  31-Aug-2015 22:11:18: Loaded trial metadata from _data/c11m1d12_ti2.txt
  31-Aug-2015 22:11:23: Loaded filters and traces from sss3\rec_150829-142325.mat
  31-Aug-2015 22:11:34: Loaded classification from sss3\class_150830-141756.txt
>> [m_2to3, m_3to2] = run_alignment(m1d12_sss1, m1d12_sss2, 'notrans');
```

Also, one-to-one matching between the two datasets is now turned on by default. To get _all_ matches, use `run_alignment` with the `keepall` vararg.

With each `DaySummary` containing 1000+ cells these days, the matching process can take quite a bit of time, up to 30 minutes in the latest CellMax matches -- with almost 2k cells. Hence, I added an optional tweak to the matching procedure that can speed up the process, to be invoked with the 'fast' option.

Time taken to match SSS2 and SSS3 without `fast` toggle: ~14 minutes.
```
>> [m_2to3, m_3to2] = run_alignment(m1d12_sss2, m1d12_sss3, 'notrans');
run_alignment: Press any key to continue with mask matching >> 
31-Aug-2015 22:12:21: Computing overlaps (2.7%)...
...
31-Aug-2015 22:26:29: Computing overlaps (98.1%)...
31-Aug-2015 22:26:47: Overlap matrix completed!
```

Time taken to match SSS2 and SSS3 with `fast` toggle: ~6 minutes.
```
>> [m_2to3f, m_3to2f] = run_alignment(m1d12_sss2, m1d12_sss3, 'notrans', 'fast');
run_alignment: Press any key to continue with mask matching >> 
31-Aug-2015 22:28:53: Using fast matching!
31-Aug-2015 22:28:58: Computing overlaps (2.7%)...
...
31-Aug-2015 22:34:31: Computing overlaps (98.1%)...
31-Aug-2015 22:34:41: Overlap matrix completed!
```

Currently, I set the criterion for fast-matching to be quite conservative. In the above comparison (SSS2 to SSS3 alignment), the matching results with and without the fast-option are 100% identical.

However, in principle, the fast-matching toggle can introduce errors. Hence, for real cross-day alignments, I'd suggest that we don't use the fast-matching option. On the other hand, when we do matches within day to, say, copy over labels, we can admit a few errors, especially if we copy over "cell" labels only (i.e. not copy over rejections).