### PR TITLE
Kimth/copy labels

### DIFF
--- a/ds/@DaySummary/DaySummary.m
+++ b/ds/@DaySummary/DaySummary.m
@@ -238,11 +238,19 @@ classdef DaySummary < handle
             class = {obj.cells.label}'; % Column cell
         end
         
-        function set_all_labels(obj, label)
+        function set_all_labels_to(obj, label)
             % Overwrites the label of all cells in DaySummary
             for k = 1:obj.num_cells
                 obj.cells(k).label = label;
             end
+        end
+        
+        function set_labels(obj)
+            obj.set_all_labels_to('cell');
+        end
+        
+        function reset_labels(obj)
+            obj.set_all_labels_to([]);
         end
     end
 end

--- a/ds/copy_labels.m
+++ b/ds/copy_labels.m
@@ -1,0 +1,16 @@
+function copy_labels(ds_source, ds_target, match)
+% Copy labels from source DaySummary to target DaySummary
+
+num_labels_copied = 0;
+
+ds_target.reset_labels();
+for k = 1:ds_source.num_cells
+    m = match{k};
+    if ~isempty(m)
+        k2 = m(1,1);
+        ds_target.cells(k2).label = ds_source.cells(k).label;
+        num_labels_copied = num_labels_copied + 1;
+    end
+end
+fprintf('  %s: Copied %d labels from "%s" to "%s"\n',...
+    datestr(now), num_labels_copied, inputname(1), inputname(2));


### PR DESCRIPTION
Added a mechanism for copying set of labels from one `DaySummary` to another. Example use:
```
>> m1d12_sss2 = DaySummary(sources.maze, 'sss2');
  01-Sep-2015 16:39:02: Loaded trial metadata from _data/c11m1d12_ti2.txt
  01-Sep-2015 16:39:09: Loaded filters and traces from sss2\rec_150827-171046.mat
  01-Sep-2015 16:39:31: Loaded classification from sss2\class_150828-092948.txt
>> m1d12_sss3 = DaySummary(sources.maze, 'sss3');
  01-Sep-2015 16:39:45: Loaded trial metadata from _data/c11m1d12_ti2.txt
  01-Sep-2015 16:39:50: Loaded filters and traces from sss3\rec_150829-142325.mat
  01-Sep-2015 16:40:16: Loaded classification from sss3\class_150830-141756.txt
>> [m_2to3, m_3to2] = run_alignment(m1d12_sss2, m1d12_sss3, 'notrans', 'fast');
run_alignment: Press any key to continue with mask matching >> 
01-Sep-2015 16:43:40: Using fast matching!
01-Sep-2015 16:43:46: Computing overlaps (2.7%)...
...
01-Sep-2015 16:51:15: Computing overlaps (98.1%)...
01-Sep-2015 16:51:28: Overlap matrix completed!
run_alignment: Applying bijective filter...
```

To copy labels from `m1d12_sss2` into `m1d12_sss3`, use the following command:
```
>> copy_labels(m1d12_sss2, m1d12_sss3, m_2to3);
  01-Sep-2015 16:59:27: Copied 563 labels from "m1d12_sss2" to "m1d12_sss3"
```

The copied labels can be viewed with `m1d12_sss3.plot_cell_map`:
![image](https://cloud.githubusercontent.com/assets/2081503/9620087/8f4d7c8a-50cb-11e5-8a91-5aef9ebb8efb.png)

The following overlay shows all the __classified cells__ in `m1d12_sss3` (red boundaries) whose label was copied from `m1d12_sss2` (blue boundaries):
![image](https://cloud.githubusercontent.com/assets/2081503/9620191/8fd43828-50cc-11e5-9eff-b215c5ddbb5d.png)
