### PR TITLE
Default save name

### DIFF
--- a/ds/@DaySummary/save_class.m
+++ b/ds/@DaySummary/save_class.m
@@ -1,5 +1,9 @@
 function save_class(obj, outfile)
 
+if ~exist('outfile', 'var')
+    outfile = sprintf('class_%s.txt', datestr(now, 'yymmdd-HHMMSS'));
+end
+
 num_candidates = obj.num_cells;
 
 fid = fopen(outfile, 'w');
@@ -7,3 +11,4 @@ for k = 1:num_candidates
     fprintf(fid, '%d, %s\n', k, obj.cells(k).label);
 end
 fclose(fid);
+fprintf('%s: Class file saved to "%s"\n', datestr(now), outfile);


### PR DESCRIPTION
When saving a classification text file from an existing `DaySummary`, a default name will be provided if `save_class` is invoked with no parameter:
```
>> m1d12_sss3 = DaySummary(sources.maze, 'sss3');
  01-Sep-2015 18:04:29: Loaded trial metadata from _data/c11m1d12_ti2.txt
  01-Sep-2015 18:04:34: Loaded filters and traces from sss3\rec_150829-142325.mat
  01-Sep-2015 18:04:52: Loaded classification from sss3\class_150830-141756.txt
>> m1d12_sss3.save_class('savename.txt')
01-Sep-2015 18:05:05: Class file saved to "savename.txt"
>> m1d12_sss3.save_class()
01-Sep-2015 18:05:11: Class file saved to "class_150901-180511.txt"
```