### PR TITLE
Fix reference to bin_frame_indices

### DIFF
--- a/behavior/bin_behavior_video.m
+++ b/behavior/bin_behavior_video.m
@@ -15,7 +15,7 @@ function binned_indices = bin_behavior_video(behavior_source, bin_factor, trial_
 %
 
 % Get the binned indices
-binned_indices = bin_frame_indices2(trial_indices, bin_factor);
+binned_indices = bin_frame_indices(trial_indices, bin_factor);
 binned_frames_per_trial = binned_indices(:,end) - binned_indices(:,1) + 1;
 num_binned_frames = sum(binned_frames_per_trial);
 num_trials = size(binned_frames_per_trial, 1);

--- a/image_op/bin_movie_in_time.m
+++ b/image_op/bin_movie_in_time.m
@@ -44,7 +44,7 @@ assert(num_frames == trial_indices(end,end),...
 %------------------------------------------------------------
 
 % Get the binned indices
-binned_indices = bin_frame_indices2(trial_indices, bin_factor);
+binned_indices = bin_frame_indices(trial_indices, bin_factor);
 binned_frames_per_trial = binned_indices(:,end) - binned_indices(:,1) + 1;
 num_binned_frames = sum(binned_frames_per_trial);
 num_trials = size(binned_frames_per_trial,1);


### PR DESCRIPTION
Hotfix accompanying the recent name change `bin_frame_indices`.