### PR TITLE
Kimth/load behavior

### DIFF
--- a/ds/@DaySummary/DaySummary.m
+++ b/ds/@DaySummary/DaySummary.m
@@ -261,7 +261,8 @@ classdef DaySummary < handle
         %------------------------------------------------------------
         function load_behavior_movie(obj, behavior_source)
             obj.behavior_vid = VideoReader(behavior_source);
-            fprintf('%s: Loaded behavior video from "%s"\n', behavior_source);
+            fprintf('%s: Loaded behavior video from "%s"\n',...
+                datestr(now), behavior_source);
             if (obj.behavior_vid.NumberOfFrames ~= obj.trial_indices(end,end))
                 fprintf('  Warning! Number of frames in behavior video (%d) does not match the trial frame table (%d)!\n',...
                     obj.behavior_vid.NumberOfFrames, obj.trial_indices(end,end));

--- a/ds/@DaySummary/DaySummary.m
+++ b/ds/@DaySummary/DaySummary.m
@@ -259,6 +259,10 @@ classdef DaySummary < handle
         
         % Load behavior movie
         %------------------------------------------------------------
+        function loaded = is_behavior_loaded(obj)
+            loaded = ~isempty(obj.behavior_vid);
+        end
+        
         function load_behavior_movie(obj, behavior_source)
             obj.behavior_vid = VideoReader(behavior_source);
             fprintf('%s: Loaded behavior video from "%s"\n',...

--- a/ds/@DaySummary/DaySummary.m
+++ b/ds/@DaySummary/DaySummary.m
@@ -25,6 +25,7 @@ classdef DaySummary < handle
     
     properties (SetAccess = private, Hidden)
         cell_map_ref_img
+        behavior_vid
     end
         
     methods
@@ -44,14 +45,14 @@ classdef DaySummary < handle
             %------------------------------------------------------------
             [trial_indices, loc_info, trial_durations] =...
                 parse_plusmaze(plusmaze_txt); %#ok<*PROP>
-            fprintf('  %s: Loaded trial metadata from %s\n', datestr(now), plusmaze_txt);
+            fprintf('%s: Loaded trial metadata from %s\n', datestr(now), plusmaze_txt);
             
             % Load data
             %------------------------------------------------------------
             data_source = get_most_recent_file(rec_dir, 'rec_*.mat');
             data = load(data_source);
             obj.num_cells = data.info.num_pairs;
-            fprintf('  %s: Loaded filters and traces from %s\n', datestr(now), data_source);
+            fprintf('%s: Loaded filters and traces from %s\n', datestr(now), data_source);
             
             % Check that the length of traces is consistent with the table
             % of trial indices.
@@ -114,8 +115,11 @@ classdef DaySummary < handle
             class_source = get_most_recent_file(rec_dir, 'class_*.txt');
             if ~isempty(class_source)
                 obj.load_class(class_source);
-                fprintf('  %s: Loaded classification from %s\n', datestr(now), class_source);
+                fprintf('%s: Loaded classification from %s\n', datestr(now), class_source);
             end
+            
+            % Other initialization
+            obj.behavior_vid = [];
             
             % Precompute cell map image, to avoid doing it each time
             %------------------------------------------------------------
@@ -251,6 +255,17 @@ classdef DaySummary < handle
         
         function reset_labels(obj)
             obj.set_all_labels_to([]);
+        end
+        
+        % Load behavior movie
+        %------------------------------------------------------------
+        function load_behavior_movie(obj, behavior_source)
+            obj.behavior_vid = VideoReader(behavior_source);
+            fprintf('%s: Loaded behavior video from "%s"\n', behavior_source);
+            if (obj.behavior_vid.NumberOfFrames ~= obj.trial_indices(end,end))
+                fprintf('  Warning! Number of frames in behavior video (%d) does not match the trial frame table (%d)!\n',...
+                    obj.behavior_vid.NumberOfFrames, obj.trial_indices(end,end));
+            end
         end
     end
 end

--- a/ds/@DaySummary/DaySummary.m
+++ b/ds/@DaySummary/DaySummary.m
@@ -272,5 +272,11 @@ classdef DaySummary < handle
                     obj.behavior_vid.NumberOfFrames, obj.trial_indices(end,end));
             end
         end
+        
+        function Mb = get_behavior_trial(obj, trial_idx)
+            trial_frames = obj.trial_indices(trial_idx, [1 end]); % [Start end]
+            Mb = obj.behavior_vid.read(trial_frames);
+            Mb = squeeze(Mb(:,:,1,:)); % Movie is actually grayscale!
+        end
     end
 end

--- a/utils/freezeColors.m
+++ b/utils/freezeColors.m
@@ -1,0 +1,275 @@
+function freezeColors(varargin)
+% freezeColors  Lock colors of plot, enabling multiple colormaps per figure. (v2.3)
+%
+%   Problem: There is only one colormap per figure. This function provides
+%       an easy solution when plots using different colomaps are desired 
+%       in the same figure.
+%
+%   freezeColors freezes the colors of graphics objects in the current axis so 
+%       that subsequent changes to the colormap (or caxis) will not change the
+%       colors of these objects. freezeColors works on any graphics object 
+%       with CData in indexed-color mode: surfaces, images, scattergroups, 
+%       bargroups, patches, etc. It works by converting CData to true-color rgb
+%       based on the colormap active at the time freezeColors is called.
+%
+%   The original indexed color data is saved, and can be restored using
+%       unfreezeColors, making the plot once again subject to the colormap and
+%       caxis.
+%
+%
+%   Usage:
+%       freezeColors        applies to all objects in current axis (gca),
+%       freezeColors(axh)   same, but works on axis axh.
+%
+%   Example:
+%       subplot(2,1,1); imagesc(X); colormap hot; freezeColors
+%       subplot(2,1,2); imagesc(Y); colormap hsv; freezeColors etc...
+%
+%       Note: colorbars must also be frozen. Due to Matlab 'improvements' this can
+%				no longer be done with freezeColors. Instead, please
+%				use the function CBFREEZE by Carlos Adrian Vargas Aguilera
+%				that can be downloaded from the MATLAB File Exchange
+%				(http://www.mathworks.com/matlabcentral/fileexchange/24371)
+%
+%       h=colorbar; cbfreeze(h), or simply cbfreeze(colorbar)
+%
+%       For additional examples, see test/test_main.m
+%
+%   Side effect on render mode: freezeColors does not work with the painters
+%       renderer, because Matlab doesn't support rgb color data in
+%       painters mode. If the current renderer is painters, freezeColors
+%       changes it to zbuffer. This may have unexpected effects on other aspects
+%	      of your plots.
+%
+%       See also unfreezeColors, freezeColors_pub.html, cbfreeze.
+%
+%
+%   John Iversen (iversen@nsi.edu) 3/23/05
+%
+
+%   Changes:
+%   JRI (iversen@nsi.edu) 4/19/06   Correctly handles scaled integer cdata
+%   JRI 9/1/06   should now handle all objects with cdata: images, surfaces, 
+%                scatterplots. (v 2.1)
+%   JRI 11/11/06 Preserves NaN colors. Hidden option (v 2.2, not uploaded)
+%   JRI 3/17/07  Preserve caxis after freezing--maintains colorbar scale (v 2.3)
+%   JRI 4/12/07  Check for painters mode as Matlab doesn't support rgb in it.
+%   JRI 4/9/08   Fix preserving caxis for objects within hggroups (e.g. contourf)
+%   JRI 4/7/10   Change documentation for colorbars
+
+% Hidden option for NaN colors:
+%   Missing data are often represented by NaN in the indexed color
+%   data, which renders transparently. This transparency will be preserved
+%   when freezing colors. If instead you wish such gaps to be filled with 
+%   a real color, add 'nancolor',[r g b] to the end of the arguments. E.g. 
+%   freezeColors('nancolor',[r g b]) or freezeColors(axh,'nancolor',[r g b]),
+%   where [r g b] is a color vector. This works on images & pcolor, but not on
+%   surfaces.
+%   Thanks to Fabiano Busdraghi and Jody Klymak for the suggestions. Bugfixes 
+%   attributed in the code.
+
+% Free for all uses, but please retain the following:
+%   Original Author:
+%   John Iversen, 2005-10
+%   john_iversen@post.harvard.edu
+
+appdatacode = 'JRI__freezeColorsData';
+
+[h, nancolor] = checkArgs(varargin);
+
+%gather all children with scaled or indexed CData
+cdatah = getCDataHandles(h);
+
+%current colormap
+cmap = colormap;
+nColors = size(cmap,1);
+cax = caxis;
+
+% convert object color indexes into colormap to true-color data using 
+%  current colormap
+for hh = cdatah',
+    g = get(hh);
+    
+    %preserve parent axis clim
+    parentAx = getParentAxes(hh);
+    originalClim = get(parentAx, 'clim');    
+   
+    %   Note: Special handling of patches: For some reason, setting
+    %   cdata on patches created by bar() yields an error,
+    %   so instead we'll set facevertexcdata instead for patches.
+    if ~strcmp(g.Type,'patch'),
+        cdata = g.CData;
+    else
+        cdata = g.FaceVertexCData; 
+    end
+    
+    %get cdata mapping (most objects (except scattergroup) have it)
+    if isfield(g,'CDataMapping'),
+        scalemode = g.CDataMapping;
+    else
+        scalemode = 'scaled';
+    end
+    
+    %save original indexed data for use with unfreezeColors
+    siz = size(cdata);
+    setappdata(hh, appdatacode, {cdata scalemode});
+
+    %convert cdata to indexes into colormap
+    if strcmp(scalemode,'scaled'),
+        %4/19/06 JRI, Accommodate scaled display of integer cdata:
+        %       in MATLAB, uint * double = uint, so must coerce cdata to double
+        %       Thanks to O Yamashita for pointing this need out
+        idx = ceil( (double(cdata) - cax(1)) / (cax(2)-cax(1)) * nColors);
+    else %direct mapping
+        idx = cdata;
+        %10/8/09 in case direct data is non-int (e.g. image;freezeColors)
+        % (Floor mimics how matlab converts data into colormap index.)
+        % Thanks to D Armyr for the catch
+        idx = floor(idx);
+    end
+    
+    %clamp to [1, nColors]
+    idx(idx<1) = 1;
+    idx(idx>nColors) = nColors;
+
+    %handle nans in idx
+    nanmask = isnan(idx);
+    idx(nanmask)=1; %temporarily replace w/ a valid colormap index
+
+    %make true-color data--using current colormap
+    realcolor = zeros(siz);
+    for i = 1:3,
+        c = cmap(idx,i);
+        c = reshape(c,siz);
+        c(nanmask) = nancolor(i); %restore Nan (or nancolor if specified)
+        realcolor(:,:,i) = c;
+    end
+    
+    %apply new true-color color data
+    
+    %true-color is not supported in painters renderer, so switch out of that
+    if strcmp(get(gcf,'renderer'), 'painters'),
+        set(gcf,'renderer','zbuffer');
+    end
+    
+    %replace original CData with true-color data
+    if ~strcmp(g.Type,'patch'),
+        set(hh,'CData',realcolor);
+    else
+        set(hh,'faceVertexCData',permute(realcolor,[1 3 2]))
+    end
+    
+    %restore clim (so colorbar will show correct limits)
+    if ~isempty(parentAx),
+        set(parentAx,'clim',originalClim)
+    end
+    
+end %loop on indexed-color objects
+
+
+% ============================================================================ %
+% Local functions
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% getCDataHandles -- get handles of all descendents with indexed CData
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+function hout = getCDataHandles(h)
+% getCDataHandles  Find all objects with indexed CData
+
+%recursively descend object tree, finding objects with indexed CData
+% An exception: don't include children of objects that themselves have CData:
+%   for example, scattergroups are non-standard hggroups, with CData. Changing
+%   such a group's CData automatically changes the CData of its children, 
+%   (as well as the children's handles), so there's no need to act on them.
+
+error(nargchk(1,1,nargin,'struct'))
+
+hout = [];
+if isempty(h),return;end
+
+ch = get(h,'children');
+for hh = ch'
+    g = get(hh);
+    if isfield(g,'CData'),     %does object have CData?
+        %is it indexed/scaled?
+        if ~isempty(g.CData) && isnumeric(g.CData) && size(g.CData,3)==1, 
+            hout = [hout; hh]; %#ok<AGROW> %yes, add to list
+        end
+    else %no CData, see if object has any interesting children
+            hout = [hout; getCDataHandles(hh)]; %#ok<AGROW>
+    end
+end
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% getParentAxes -- return handle of axes object to which a given object belongs
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+function hAx = getParentAxes(h)
+% getParentAxes  Return enclosing axes of a given object (could be self)
+
+error(nargchk(1,1,nargin,'struct'))
+%object itself may be an axis
+if strcmp(get(h,'type'),'axes'),
+    hAx = h;
+    return
+end
+
+parent = get(h,'parent');
+if (strcmp(get(parent,'type'), 'axes')),
+    hAx = parent;
+else
+    hAx = getParentAxes(parent);
+end
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% checkArgs -- Validate input arguments
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+function [h, nancolor] = checkArgs(args)
+% checkArgs  Validate input arguments to freezeColors
+
+nargs = length(args);
+error(nargchk(0,3,nargs,'struct'))
+
+%grab handle from first argument if we have an odd number of arguments
+if mod(nargs,2),
+    h = args{1};
+    if ~ishandle(h),
+        error('JRI:freezeColors:checkArgs:invalidHandle',...
+            'The first argument must be a valid graphics handle (to an axis)')
+    end
+    % 4/2010 check if object to be frozen is a colorbar
+    if strcmp(get(h,'Tag'),'Colorbar'),
+      if ~exist('cbfreeze.m'),
+        warning('JRI:freezeColors:checkArgs:cannotFreezeColorbar',...
+            ['You seem to be attempting to freeze a colorbar. This no longer'...
+            'works. Please read the help for freezeColors for the solution.'])
+      else
+        cbfreeze(h);
+        return
+      end
+    end
+    args{1} = [];
+    nargs = nargs-1;
+else
+    h = gca;
+end
+
+%set nancolor if that option was specified
+nancolor = [nan nan nan];
+if nargs == 2,
+    if strcmpi(args{end-1},'nancolor'),
+        nancolor = args{end};
+        if ~all(size(nancolor)==[1 3]),
+            error('JRI:freezeColors:checkArgs:badColorArgument',...
+                'nancolor must be [r g b] vector');
+        end
+        nancolor(nancolor>1) = 1; nancolor(nancolor<0) = 0;
+    else
+        error('JRI:freezeColors:checkArgs:unrecognizedOption',...
+            'Unrecognized option (%s). Only ''nancolor'' is valid.',args{end-1})
+    end
+end
+
+

--- a/utils/unfreezeColors.m
+++ b/utils/unfreezeColors.m
@@ -1,0 +1,106 @@
+function unfreezeColors(h)
+% unfreezeColors  Restore colors of a plot to original indexed color. (v2.3)
+%
+%   Useful if you want to apply a new colormap to plots whose
+%       colors were previously frozen with freezeColors.
+%
+%   Usage:
+%       unfreezeColors          unfreezes all objects in current axis, 
+%       unfreezeColors(axh)     same, but works on axis axh. axh can be vector.
+%       unfreezeColors(figh)    same, but for all objects in figure figh.
+%
+%       Has no effect on objects on which freezeColors was not already called.
+%				(Note: if colorbars were frozen using cbfreeze, use cbfreeze('off') to 
+%       unfreeze them. See freezeColors for information on cbfreeze.)
+%
+%
+%   See also freezeColors, freezeColors_pub.html, cbfreeze.
+%
+%
+%   John Iversen (iversen@nsi.edu) 3/23/05
+%
+
+%   Changes:
+%   JRI 9/1/06 now restores any object with frozen CData;
+%              can unfreeze an entire figure at once.
+%   JRI 4/7/10 Change documentation for colorbars
+
+% Free for all uses, but please retain the following:
+%
+%   Original Author:
+%   John Iversen, 2005-10
+%   john_iversen@post.harvard.edu
+
+error(nargchk(0,1,nargin,'struct'))
+
+appdatacode = 'JRI__freezeColorsData';
+
+%default: operate on gca
+if nargin < 1,
+    h = gca;
+end
+
+if ~ishandle(h),
+     error('JRI:unfreezeColors:invalidHandle',...
+            'The argument must be a valid graphics handle to a figure or axis')
+end
+
+%if h is a figure, loop on its axes
+if strcmp(get(h,'type'),'figure'),
+    h = get(h,'children');
+end
+
+for h1 = h', %loop on axes
+
+    %process all children, acting only on those with saved CData
+    %   ( in appdata JRI__freezeColorsData)
+    ch = findobj(h1);
+    
+    for hh = ch',
+        
+        %some object handles may be invalidated when their parent changes 
+        %   (e.g. restoring colors of a scattergroup unfortunately changes
+        %   the handles of all its children). So, first check to make sure
+        %   it's a valid handle
+        if ishandle(hh)
+            if isappdata(hh,appdatacode),
+                ad = getappdata(hh,appdatacode);
+                %get oroginal cdata
+                %patches have to be handled separately (see note in freezeColors)
+                if ~strcmp(get(hh,'type'),'patch'),
+                    cdata = get(hh,'CData');
+                else
+                    cdata = get(hh,'faceVertexCData');
+                    cdata = permute(cdata,[1 3 2]);
+                end
+                indexed = ad{1};
+                scalemode = ad{2};
+                
+                %size consistency check
+                if all(size(indexed) == size(cdata(:,:,1))),
+                    %ok, restore indexed cdata
+                    if ~strcmp(get(hh,'type'),'patch'),
+                        set(hh,'CData',indexed);
+                    else
+                        set(hh,'faceVertexCData',indexed);
+                    end
+                    %restore cdatamapping, if needed
+                    g = get(hh);
+                    if isfield(g,'CDataMapping'),
+                        set(hh,'CDataMapping',scalemode);
+                    end
+                    %clear appdata
+                    rmappdata(hh,appdatacode)
+                else
+                    warning('JRI:unfreezeColors:internalCdataInconsistency',...
+                        ['Could not restore indexed data: it is the wrong size. ' ...
+                        'Were the axis contents changed since the call to freezeColors?'])
+                end
+                
+            end %test if has our appdata
+        end %test ishandle
+
+    end %loop on children
+
+end %loop on axes
+

--- a/view/browse_rasters.m
+++ b/view/browse_rasters.m
@@ -17,6 +17,8 @@ cells_per_page = [2 4];
 num_cells_per_page = prod(cells_per_page);
 num_pages = ceil(num_cells / num_cells_per_page);
 
+h = figure;
+
 page_idx = 1;
 while (1)
     clf;
@@ -66,6 +68,7 @@ while (1)
                 page_idx = 1;
                 
             case 'q' % Exit
+                close(h);
                 break;
 
             otherwise

--- a/view/browse_rasters.m
+++ b/view/browse_rasters.m
@@ -13,7 +13,7 @@ cell_indices = find(ds.is_cell);
 num_cells = length(cell_indices);
 
 % Display settings
-cells_per_page = [2 3];
+cells_per_page = [2 4];
 num_cells_per_page = prod(cells_per_page);
 num_pages = ceil(num_cells / num_cells_per_page);
 

--- a/view/view_detailed_raster.m
+++ b/view/view_detailed_raster.m
@@ -10,7 +10,7 @@ function view_detailed_raster(ds, cell_idx)
 
 while (1)
     clf;
-    draw_rasters(); 
+    scale = draw_rasters(); 
     
     % Ask user for command
     prompt = sprintf('Cell %d raster >> ', cell_idx);
@@ -47,7 +47,7 @@ end
 
     % Helper functions
     %------------------------------------------------------------
-    function draw_rasters()
+    function raster_scale = draw_rasters()
         % Image of cell
         subplot(3,4,[1 2]);
         imagesc(ds.cells(cell_idx).im);
@@ -95,23 +95,22 @@ end
 
     function draw_trial(trial_idx)
         Mb = ds.get_behavior_trial(trial_idx); % Behavior movie
-        tr = ds.trials(trial_idx).traces(cell_idx,:);
-        num_frames_in_trial = length(tr);
+        trace = ds.trials(trial_idx).traces(cell_idx,:);
+        num_frames_in_trial = length(trace);
         
         % Show trace
         subplot(3,4,[3 4]);
-        plot(1:num_frames_in_trial, tr);
-        xlim([1 num_frames_in_trial]);
-        y_min = min(tr);
-        y_max = max(tr);
-        y_range = [y_min y_max] + 0.1*(y_max-y_min)*[-1 1];
-        ylim(y_range);
+        trial_phase = linspace(0, 1, num_frames_in_trial);
+        plot(trial_phase, trace,...
+             'HitTest', 'off');
+        xlim([0 1]);
+        ylim(scale);
         grid on;
         title(sprintf('Trial %d', trial_idx));
-        xlabel('Frames');
+        xlabel('Trial phase [a.u.]');
         ylabel('Signal [a.u.]');
         hold on;
-        t = plot(1*[1 1], y_range, 'k');
+        t = plot(0*[1 1], scale, 'k--');
         set(gca, 'ButtonDownFcn', @update_frame);
         
         % Show behavior movie
@@ -124,10 +123,12 @@ end
         
         function update_frame(h, ~)
             cp = get(h, 'CurrentPoint');
-            sel_frame = round(cp(1)); % X point of click
-            sel_frame = max(sel_frame, 1);
-            sel_frame = min(sel_frame, num_frames_in_trial);
-            set(t, 'XData', sel_frame*[1 1]);
+            sel_phase = cp(1); % X point of click
+            sel_phase = max(sel_phase, 0);
+            sel_phase = min(sel_phase, 1);
+            
+            sel_frame = round(num_frames_in_trial * sel_phase);
+            set(t, 'XData', sel_phase*[1 1]);
             set(hb, 'CData', Mb(:,:,sel_frame));
         end % update_frame
     end % draw_trial

--- a/view/view_detailed_raster.m
+++ b/view/view_detailed_raster.m
@@ -104,19 +104,31 @@ end
         xlim([1 num_frames_in_trial]);
         y_min = min(tr);
         y_max = max(tr);
-        y_range = y_max - y_min;
-        ylim([y_min y_max] + 0.1*y_range*[-1 1]);
+        y_range = [y_min y_max] + 0.1*(y_max-y_min)*[-1 1];
+        ylim(y_range);
         grid on;
         title(sprintf('Trial %d', trial_idx));
         xlabel('Frames');
         ylabel('Signal [a.u.]');
+        hold on;
+        t = plot(1*[1 1], y_range, 'k');
+        set(gca, 'ButtonDownFcn', @update_frame);
         
         % Show behavior movie
         subplot(3,4,[7 8 11 12]);
-        imagesc(Mb(:,:,1));
+        hb = imagesc(Mb(:,:,1));
         set(gca, 'XTick', []);
         set(gca, 'YTick', []);
         colormap gray;
         pause;
+        
+        function update_frame(h, ~)
+            cp = get(h, 'CurrentPoint');
+            sel_frame = round(cp(1)); % X point of click
+            sel_frame = max(sel_frame, 1);
+            sel_frame = min(sel_frame, num_frames_in_trial);
+            set(t, 'XData', sel_frame*[1 1]);
+            set(hb, 'CData', Mb(:,:,sel_frame));
+        end % update_frame
     end % draw_trial
 end % view_cell_rasters

--- a/view/view_detailed_raster.m
+++ b/view/view_detailed_raster.m
@@ -22,7 +22,7 @@ while (1)
             fprintf('  Behavior video not loaded into DaySummary!\n');
         else
             if ((1 <= val) && (val <= ds.num_trials))
-                fprintf('  Showing trial %d. Press any key to return >> \n', val);
+                fprintf('  Showing trial %d. Press any key to return.\n', val);
                 draw_trial(val);
             else
                 fprintf('  Error, %d is not a valid trial index!\n', val);
@@ -108,12 +108,14 @@ end
         ylim([y_min y_max] + 0.1*y_range*[-1 1]);
         grid on;
         title(sprintf('Trial %d', trial_idx));
+        xlabel('Frames');
+        ylabel('Signal [a.u.]');
         
         % Show behavior movie
         subplot(3,4,[7 8 11 12]);
-        hb = imagesc(Mb(:,:,1));
-        set(hb, 'XTicks', []);
-        set(hb, 'YTicks', []);
+        imagesc(Mb(:,:,1));
+        set(gca, 'XTick', []);
+        set(gca, 'YTick', []);
         colormap gray;
         pause;
     end % draw_trial


### PR DESCRIPTION
@forea, @inanhkn This is an initial foray into integrating the behavior video into our analysis workflow. My guess is that things will evolve a lot from this point (e.g. visualization methods), but wanted to run by the initial implementation.

First, you should instantiate a `DaySummary` object as before:
```
>> sources = data_sources

sources = 

         maze: '_data/c11m1d12_ti2.txt'
     behavior: '_data/c11m1d12_ti2.mp4'
    miniscope: '_data/c11m1d12_cr_gfix_mc_cr_norm_dff_ti2.hdf5'
          pca: '_data/pca_n700.mat'
          fps: 10

>> m1d12_cm001 = DaySummary(sources.maze, 'cm001');
03-Sep-2015 16:12:40: Loaded trial metadata from _data/c11m1d12_ti2.txt
03-Sep-2015 16:12:43: Loaded filters and traces from cm001\rec_150817-165436.mat
03-Sep-2015 16:13:01: Loaded classification from cm001\class_150819-123923.txt
```

By default, `DaySummary` does not initialize the behavior video. Instead, you can "load" the behavior video into `DaySummary` afterwards as follows:
```
>> m1d12_cm001.load_behavior_movie(sources.behavior);
03-Sep-2015 16:20:07: Loaded behavior video from "_data/c11m1d12_ti2.mp4"
```
For now, I made the behavior video something you can optionally load after the initial construction of `DaySummary`. I did it this way for now, because I thought that there may be cases (e.g. classification of cells) where we would use `DaySummary`s without having to refer to the behavior video. We could use alternate loading schemes in the future.

The use of the `sources` struct is optional. You can directly specify the path to the behavior video. Note: `load_behavior_movie` will issue a warning if the number of frames in the behavior movie does not match the expected number of frames in the frame indices table. This could be an issue on Ubuntu systems where the behavior videos (MP4 files) seem to underreport by one frame.

As a start, I created one "application" that makes use of the behavior video (`browse_rasters.m` which I introduced a little bit ago). Using the "c11m1d12_cm001" dataset:
```
>> browse_rasters(m1d12_cm001);
Raster browser (page 1 of 53) >> 
```
![image](https://cloud.githubusercontent.com/assets/2081503/9673325/1e321158-5258-11e5-98a4-51c2f5507cd4.png)

I then select a particular cell, to view the detailed raster. For example, cell 23:
```
>> browse_rasters(m1d12_cm001);
Raster browser (page 1 of 53) >> 23
  Cell 23 selected!
Cell 23 raster >> 
```
![image](https://cloud.githubusercontent.com/assets/2081503/9673487/8a17d3e8-5259-11e5-9c61-186429ce6bdf.png)

At this point, you can type '3' to look at trial 3:
![image](https://cloud.githubusercontent.com/assets/2081503/9675574/646c386c-5274-11e5-8db2-1d0b7e4850ff.png)
which shows the trace for this cell in trial 3, and the corresponding behavior video. You are now able to click on the top right trace, to view the corresponding behavior frame:
![image](https://cloud.githubusercontent.com/assets/2081503/9675600/b10d4dc8-5274-11e5-8d97-02686c5631be.png)

You can return to the raster by hitting any key on the keyboard:
```
Cell 23 raster >> 3
  Showing trial 3. Press any key to return.
Cell 23 raster >> 
```

This is just the first pass at integrating the behavior video -- I'm sure we'll come up with better visualizations as we further work with behavior videos.